### PR TITLE
chore(a11y): update links in footer and delete legal.proconnect.gouv.fr references

### DIFF
--- a/src/views/partials/footer.ejs
+++ b/src/views/partials/footer.ejs
@@ -1,71 +1,118 @@
 <footer class="fr-footer" role="contentinfo" id="footer" tabindex="-1">
-    <div class="fr-container">
-        <div class="fr-footer__body">
-            <div class="fr-footer__brand">
-                <span class="fr-logo">
-                    République<br>
-                    Française
-                </span>
-            </div>
-            <div class="fr-footer__content">
-                <ul class="fr-footer__content-list">
-                    <li class="fr-footer__content-item">
-                        <a class="fr-footer__content-link" target="_blank" rel="noopener external" title="info.gouv.fr - nouvelle fenêtre" href="https://info.gouv.fr">info.gouv.fr
-                        <span class="visually-hidden"> - nouvelle fenêtre</span>
-                        </a>
-                    </li>
-                    <li class="fr-footer__content-item">
-                        <a class="fr-footer__content-link" target="_blank" rel="noopener external" title="service-public.fr - nouvelle fenêtre" href="https://service-public.fr">service-public.fr
-                        <span class="visually-hidden"> - nouvelle fenêtre</span>
-                        </a>
-                    </li>
-                    <li class="fr-footer__content-item">
-                        <a class="fr-footer__content-link" target="_blank" rel="noopener external" title="legifrance.gouv.fr - nouvelle fenêtre" href="https://legifrance.gouv.fr">legifrance.gouv.fr
-                        <span class="visually-hidden"> - nouvelle fenêtre</span>
-                        </a>
-                    </li>
-                    <li class="fr-footer__content-item">
-                        <a class="fr-footer__content-link" target="_blank" rel="noopener external" title="data.gouv.fr - nouvelle fenêtre" href="https://data.gouv.fr">data.gouv.fr
-                        <span class="visually-hidden"> - nouvelle fenêtre</span>
-                        </a>
-                    </li>
-                </ul>
-            </div>
-        </div>
-        <div class="fr-footer__bottom">
-            <ul class="fr-footer__bottom-list">
-                <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="https://proconnect.crisp.help/fr/">Aide</a>
-                </li>
-                <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="https://www.proconnect.gouv.fr/">À propos</a>
-                </li>
-                <li class="fr-footer__bottom-item">
-                    <a
-                        class="fr-footer__bottom-link"
-                        href="https://legal.proconnect.gouv.fr/politique-de-confidentialite">
-                        Politique de confidentialité
-                    </a>
-                </li>
-                <li class="fr-footer__bottom-item">
-                    <a
-                        class="fr-footer__bottom-link"
-                        href="https://legal.proconnect.gouv.fr/conditions-generales-d-utilisation">
-                        Conditions générales d’utilisation
-                    </a>
-                </li>
-                <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="https://legal.proconnect.gouv.fr/accessibilite">
-                        Accessibilité : non conforme
-                    </a>
-                </li>
-            </ul>
-            <div class="fr-footer__bottom-copy">
-                <p>Sauf mention contraire, tous les contenus de ce site sont sous <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" target="_blank" rel="noopener noreferrer">licence etalab-2.0
-                <span class="visually-hidden"> - nouvelle fenêtre</span>
-                </a>
-                </p>
-            </div>
-        </div>
+  <div class="fr-container">
+    <div class="fr-footer__body">
+      <div class="fr-footer__brand">
+        <span class="fr-logo">
+          République<br />
+          Française
+        </span>
+      </div>
+      <div class="fr-footer__content">
+        <ul class="fr-footer__content-list">
+          <li class="fr-footer__content-item">
+            <a
+              class="fr-footer__content-link"
+              target="_blank"
+              rel="noopener external"
+              title="info.gouv.fr - nouvelle fenêtre"
+              href="https://info.gouv.fr"
+              >info.gouv.fr
+              <span class="visually-hidden"> - nouvelle fenêtre</span>
+            </a>
+          </li>
+          <li class="fr-footer__content-item">
+            <a
+              class="fr-footer__content-link"
+              target="_blank"
+              rel="noopener external"
+              title="service-public.fr - nouvelle fenêtre"
+              href="https://service-public.fr"
+              >service-public.fr
+              <span class="visually-hidden"> - nouvelle fenêtre</span>
+            </a>
+          </li>
+          <li class="fr-footer__content-item">
+            <a
+              class="fr-footer__content-link"
+              target="_blank"
+              rel="noopener external"
+              title="legifrance.gouv.fr - nouvelle fenêtre"
+              href="https://legifrance.gouv.fr"
+              >legifrance.gouv.fr
+              <span class="visually-hidden"> - nouvelle fenêtre</span>
+            </a>
+          </li>
+          <li class="fr-footer__content-item">
+            <a
+              class="fr-footer__content-link"
+              target="_blank"
+              rel="noopener external"
+              title="data.gouv.fr - nouvelle fenêtre"
+              href="https://data.gouv.fr"
+              >data.gouv.fr
+              <span class="visually-hidden"> - nouvelle fenêtre</span>
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
+    <div class="fr-footer__bottom">
+      <ul class="fr-footer__bottom-list">
+        <li class="fr-footer__bottom-item">
+          <a
+            class="fr-footer__bottom-link"
+            href="https://proconnect.crisp.help/fr/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Aide
+            <span class="visually-hidden"> - nouvelle fenêtre</span>
+          </a>
+        </li>
+        <li class="fr-footer__bottom-item">
+          <a
+            class="fr-footer__bottom-link"
+            href="https://www.proconnect.gouv.fr/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >À propos
+            <span class="visually-hidden"> - nouvelle fenêtre</span>
+          </a>
+        </li>
+        <li class="fr-footer__bottom-item">
+          <a
+            class="fr-footer__bottom-link"
+            href="https://www.proconnect.gouv.fr/cgu"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Conditions générales d’utilisation
+            <span class="visually-hidden"> - nouvelle fenêtre</span>
+          </a>
+        </li>
+        <li class="fr-footer__bottom-item">
+          <a
+            class="fr-footer__bottom-link"
+            href="https://www.proconnect.gouv.fr/accessibilite"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Accessibilité : non conforme
+            <span class="visually-hidden"> - nouvelle fenêtre</span>
+          </a>
+        </li>
+      </ul>
+      <div class="fr-footer__bottom-copy">
+        <p>
+          Sauf mention contraire, tous les contenus de ce site sont sous
+          <a
+            href="https://github.com/etalab/licence-ouverte/blob/master/LO.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            >licence etalab-2.0
+            <span class="visually-hidden"> - nouvelle fenêtre</span>
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
 </footer>


### PR DESCRIPTION
For some evidents reasons, I delete this reference : 
https://legal.proconnect.gouv.fr/politique-de-confidentialite
Do we need create a page with the content into the landing page ? 
The same question applies to the ProConnect Federation, which redirects to the CGU, making it redundant.
cc @renardpal @rdubigny @arnaud-robin @douglasduteil @gdarquie 