### PR TITLE
🔧 fix TypeScript types and null safety for PostgreSQL operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "@types/node": "^24.3.1",
         "@types/nodemailer": "^6.4.17",
         "@types/oidc-provider": "^9.1.1",
+        "@types/pg": "^8.15.5",
         "@types/qrcode": "^1.5.5",
         "axe-core": "^4.10.3",
         "concurrently": "^9.1.2",
@@ -2377,6 +2378,17 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-pg/node_modules/@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
       "version": "0.46.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.1.tgz",
@@ -3697,9 +3709,10 @@
       }
     },
     "node_modules/@types/pg": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
-      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "version": "8.15.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
+      "integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@types/node": "^24.3.1",
     "@types/nodemailer": "^6.4.17",
     "@types/oidc-provider": "^9.1.1",
+    "@types/pg": "^8.15.5",
     "@types/qrcode": "^1.5.5",
     "axe-core": "^4.10.3",
     "concurrently": "^9.1.2",

--- a/src/repositories/authenticator.ts
+++ b/src/repositories/authenticator.ts
@@ -138,5 +138,5 @@ export const deleteAuthenticator = async (
     [user_id, credential_id],
   );
 
-  return rowCount > 0;
+  return (rowCount ?? 0) > 0;
 };

--- a/src/repositories/moderation.ts
+++ b/src/repositories/moderation.ts
@@ -74,5 +74,5 @@ export const deleteModeration = async (id: number) => {
     [id],
   );
 
-  return rowCount > 0;
+  return (rowCount ?? 0) > 0;
 };

--- a/src/repositories/organization/setters.ts
+++ b/src/repositories/organization/setters.ts
@@ -31,5 +31,5 @@ WHERE user_id = $1 AND organization_id = $2`,
     [user_id, organization_id],
   );
 
-  return rowCount > 0;
+  return (rowCount ?? 0) > 0;
 };

--- a/src/repositories/user.ts
+++ b/src/repositories/user.ts
@@ -63,7 +63,7 @@ export const deleteUser = async (id: number) => {
     [id],
   );
 
-  return rowCount > 0;
+  return (rowCount ?? 0) > 0;
 };
 
 export const getFranceConnectUserInfo = getFranceConnectUserInfoFactory({


### PR DESCRIPTION
<div align=center><img src="https://media4.giphy.com/media/v1.Y2lkPWVjMTJjNzA0cDA3a283dHZ1dWowMWp5NDh1aXBkMmR1dXlibWF3eDJnbG5raWtnYSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/KkZPnRUQ7o8u5WWfQc/giphy.gif" /></div>

---

This PR fixes TypeScript type issues and null safety problems in PostgreSQL operations:

• **Add @types/pg@8.15.5** to fix missing TypeScript definitions
• **Fix rowCount null safety** in repositories (authenticator, moderation, organization/setters, user)
• **Ensure proper type checking** for database operation results

This resolves TypeScript strict null check issues where `rowCount` could be undefined, making the codebase more robust and type-safe.