### PR TITLE
📌 fix simplewebauthn version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,31 @@ updates:
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
+      - dependency-name:
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "@simplewebauthn/server"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "@simplewebauthn/browser"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "@simplewebauthn/types"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "@simplewebauthn/typescript-types"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
   - package-ecosystem: "docker"
     directory: "/"
     labels:


### PR DESCRIPTION
Passkey usage is not tested end-to-end.

An open issue in Cypress prevents us from writing such tests:
👉 https://github.com/cypress-io/cypress/issues/6991#issuecomment-2168311131

Our attempt to test it:
👉 https://github.com/proconnect-gouv/proconnect-identite/pull/596

To avoid accidental merges without understanding the consequences, I propose pinning the version until we find a reliable way to test it.