### PR TITLE
🔒 fix(moderation): return default reason instead of exposing moderator identity

### DIFF
--- a/cypress/e2e/join_org_with_rejected_moderation/fixtures.sql
+++ b/cypress/e2e/join_org_with_rejected_moderation/fixtures.sql
@@ -8,10 +8,12 @@ INSERT INTO organizations
   (id, siret, created_at, updated_at)
 VALUES
   (1, '66204244933106', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (2, '66204244914742', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+  (2, '66204244914742', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (3, '66204244905476', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 INSERT INTO moderations
   (id, user_id, organization_id, type, created_at, moderated_at, comment, moderated_by, ticket_id)
 VALUES
   (1, 1, 1, 'organization_join_block', CURRENT_TIMESTAMP - INTERVAL '2 days', CURRENT_TIMESTAMP - INTERVAL '1 day', 'Rejeté par moderator@yopmail.com | Raison : "Nom de domaine introuvable"', 'moderator@yopmail.com', NULL),
-  (2, 1, 2, 'organization_join_block', CURRENT_TIMESTAMP - INTERVAL '2 days', CURRENT_TIMESTAMP - INTERVAL '1 day', 'Rejeté par moderator@yopmail.com | Raison : "Inversion Nom et Prénom"', 'moderator@yopmail.com', NULL);
+  (2, 1, 2, 'organization_join_block', CURRENT_TIMESTAMP - INTERVAL '2 days', CURRENT_TIMESTAMP - INTERVAL '1 day', 'Rejeté par moderator@yopmail.com | Raison : "Inversion Nom et Prénom"', 'moderator@yopmail.com', NULL),
+  (3, 1, 3, 'organization_join_block', CURRENT_TIMESTAMP - INTERVAL '2 days', CURRENT_TIMESTAMP - INTERVAL '1 day', 'Rejeté par moderator@yopmail.com | Documents insuffisants', 'moderator@yopmail.com', NULL);

--- a/cypress/e2e/join_org_with_rejected_moderation/index.cy.ts
+++ b/cypress/e2e/join_org_with_rejected_moderation/index.cy.ts
@@ -59,4 +59,26 @@ describe("join organization with rejected moderation", () => {
     cy.contains("Demande en cours");
     cy.contains("Nom Le Bon");
   });
+
+  it("should show default reason when moderation comment has no standard format", function () {
+    cy.visit("/");
+
+    cy.title().should("include", "S'inscrire ou se connecter - ProConnect");
+    cy.login("rejected.user@yopmail.com");
+
+    cy.title().should("include", "Rejoindre une organisation - ProConnect");
+    cy.contains("SIRET de l’organisation que vous représentez").click();
+    cy.focused().clear().type("66204244905476");
+    cy.contains("Enregistrer").click();
+
+    cy.title().should("include", "Demande refusée - ProConnect");
+    cy.contains("Demande refusée");
+    cy.contains("Motif : Raison non spécifiée");
+    cy.contains(
+      "Nous n'avons pu établir aucun lien entre votre profil et l'organisation",
+    );
+    cy.contains("Rechercher une autre organisation").click();
+
+    cy.title().should("include", "Rejoindre une organisation - ProConnect");
+  });
 });

--- a/src/services/moderation.test.ts
+++ b/src/services/moderation.test.ts
@@ -33,22 +33,16 @@ describe("extractRejectionReason", () => {
     assert.strictEqual(result, "Profil incomplet");
   });
 
-  it("should fallback to original comment when no quoted reason pattern", () => {
+  it("should fallback to default reason when no quoted reason pattern", () => {
     const comment = "Rejeté par moderator@yopmail.com | Documents insuffisants";
     const result = extractRejectionReason(comment);
-    assert.strictEqual(
-      result,
-      "Rejeté par moderator@yopmail.com | Documents insuffisants",
-    );
+    assert.strictEqual(result, "Raison non spécifiée");
   });
 
-  it("should return original comment when no standard format", () => {
+  it("should return default reason when no standard format", () => {
     const comment = "Demande rejetée pour cause de données manquantes";
     const result = extractRejectionReason(comment);
-    assert.strictEqual(
-      result,
-      "Demande rejetée pour cause de données manquantes",
-    );
+    assert.strictEqual(result, "Raison non spécifiée");
   });
 
   it("should handle null comment", () => {

--- a/src/services/moderation.ts
+++ b/src/services/moderation.ts
@@ -25,8 +25,8 @@ export const extractRejectionReason = (comment: string | null): string => {
     }
   }
 
-  // Last fallback: return the original comment
-  return comment;
+  // Last fallback: return default reason (never expose moderator identity)
+  return "Raison non spécifiée";
 };
 
 /**


### PR DESCRIPTION
When extracting rejection reasons from moderation comments, the function now returns a default reason ("Raison non spécifiée") instead of the original comment when the standard format is not found. This prevents potential exposure of moderator identities.