### PR TITLE
Update fixtures

### DIFF
--- a/scripts/fixtures.sql
+++ b/scripts/fixtures.sql
@@ -3398,7 +3398,7 @@ VALUES
     'client_id_mss_dev',
     'client_secret_mss_dev',
     ARRAY['http://localhost:3000/api/proconnect/login-callback'],
-    ARRAY['http://localhost:3000/api/proconnect/logout'],
+    ARRAY['http://localhost:3000/auth/logout'],
     'openid email siret custom',
     'http://dev.mon-suivi-social.local',
     'Dev local de Mon Suivi Social',


### PR DESCRIPTION
Plutôt que de supprimer l'entrée de test pour l'outil d'évaluation budgétaire pour Strasbourg et d'ajouter une entrée pour des tests en local de Mon Suivi Social j'ai remplacé sur place.


https://gitlab.com/incubateur-territoires/startups/monsuivisocial/monsuivisocial-v2/-/blob/main/utils/routes/auth.ts#L14-26

https://gitlab.com/incubateur-territoires/startups/monsuivisocial/monsuivisocial-v2/-/blob/main/server/lib/proconnect.client.ts#L149
https://gitlab.com/incubateur-territoires/startups/monsuivisocial/monsuivisocial-v2/-/blob/main/server/lib/proconnect.client.ts#L174