### PR TITLE
fix(dependabot): 🔧 remove invalid ignore entry with null dependency-name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,11 +23,6 @@ updates:
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
-      - dependency-name:
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
       - dependency-name: "@simplewebauthn/server"
         update-types:
           - "version-update:semver-major"


### PR DESCRIPTION
<div align=center><img src="https://media4.giphy.com/media/v1.Y2lkPWVjMTJjNzA0czJvdTNqcnRpbjA5cnc4dHFmdnNheXltcmlraGh0ZXUyYXBqanBqNyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/eiRVTtaWXcuYy6G0eP/giphy.gif" /></div>

---

Fixes validation error where dependency-name field was empty instead of containing a package name string.

See https://github.com/proconnect-gouv/proconnect-identite/pull/1433/checks?check_run_id=51347516017
> The property '#/updates/1/ignore/1/dependency-name' of type null did not match the following type: string