### PR TITLE
fix(dependabot): 🔧 remove invalid ignore entry with null dependency-name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3597,9 +3597,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.18.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.7.tgz",
-      "integrity": "sha512-3E97nlWEVp2V6J7aMkR8eOnw/w0pArPwf/5/W0865f+xzBoGL/ZuHkTAKAGN7cOWNwd+sG+hZOqj+fjzeHS75g==",
+      "version": "22.18.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.8.tgz",
+      "integrity": "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"


### PR DESCRIPTION
<div align=center><img src="https://media0.giphy.com/media/v1.Y2lkPWVjMTJjNzA0ZmZjMng0YW5jdDZqZ3d5OGFxOXR0ZnVoeG4zNGc0NjU3djV4d296ayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3d4wdqPIo0oBWiNNVl/giphy.gif" /></div>

---

## What happened

The package.json specifies `@types/node@^22.18.6`, which allows npm to install any compatible version from 22.18.6 up to (but not including) 23.0.0.

When `npm install` ran, it resolved to the latest compatible version (`22.18.8`) and updated the lock file accordingly. However, this created a mismatch that breaks `npm ci`:

```
Invalid: lock file's @types/node@22.18.7 does not satisfy @types/node@22.18.8
```

## The fix

This PR commits the updated lock file to sync it with the current resolved dependency version, allowing `npm ci` to work again.