### PR TITLE
fix(changeset): 🔧 correct package name from @gouvfr-lasuite to @proconnect-gouv

### DIFF
--- a/.changeset/free-bushes-stay.md
+++ b/.changeset/free-bushes-stay.md
@@ -1,5 +1,5 @@
 ---
-"@gouvfr-lasuite/proconnect.identite": minor
+"@proconnect-gouv/proconnect.identite": minor
 ---
 
 ✨ Ajout de la fonction `isPublicService` pour identifier les services publics
@@ -9,7 +9,7 @@ Nouvelle fonction exportée permettant de déterminer si une organisation est un
 Inspirée par https://github.com/annuaire-entreprises-data-gouv-fr/search-infra/blob/f1e56ac476b0b1730115f7b1f0667e8509ee5379/workflows/data_pipelines/elasticsearch/data_enrichment.py#L155-L189
 
 ```
-import { isPublicService } from "@gouvfr-lasuite/proconnect.identite/services/organization";
+import { isPublicService } from "@proconnect-gouv/proconnect.identite/services/organization";
 
 isPublicService(my_oganization) =>> true/false
 ```


### PR DESCRIPTION
<div align=center><img src="https://media0.giphy.com/media/v1.Y2lkPWVjMTJjNzA0emFvNHh0YzM4d3k3MmttZ2VveDZnMHViN2czbmJmOGtvbHFhZHc5eCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/7J4P7cUur2DlErijp3/giphy.gif" /></div>

---

Corrige le nom du package dans le changeset `free-bushes-stay.md` pour utiliser le namespace officiel `@proconnect-gouv` au lieu de l'ancien `@gouvfr-lasuite`.

**Problème résolu :**
```
🦋  error Error: Found changeset free-bushes-stay for package @gouvfr-lasuite/proconnect.identite which is not in the workspace
```

**Changements :**
- Mise à jour du package name de `@gouvfr-lasuite/proconnect.identite` vers `@proconnect-gouv/proconnect.identite`
- Correction de l'import dans l'exemple de code