### PR TITLE
♻️  Refactor code sent to official email

### DIFF
--- a/migrations/1768582795308_remove-need-contact-email-verification.cjs
+++ b/migrations/1768582795308_remove-need-contact-email-verification.cjs
@@ -1,0 +1,15 @@
+exports.shorthands = undefined;
+
+exports.up = async (pgm) => {
+  await pgm.db.query(`
+    ALTER TABLE users_organizations
+    DROP COLUMN needs_official_contact_email_verification;
+  `);
+};
+
+exports.down = async (pgm) => {
+  await pgm.db.query(`
+    ALTER TABLE users_organizations
+    ADD COLUMN needs_official_contact_email_verification boolean NOT NULL DEFAULT FALSE;
+`);
+};

--- a/packages/database/schema.sql
+++ b/packages/database/schema.sql
@@ -423,7 +423,6 @@ CREATE TABLE "public"."users_organizations" (
   "updated_at" timestamp with time zone DEFAULT '1970-01-01 00:00:00'::timestamp without time zone NOT NULL,
   "verification_type" character varying,
   "has_been_greeted" boolean DEFAULT false NOT NULL,
-  "needs_official_contact_email_verification" boolean DEFAULT false NOT NULL,
   "official_contact_email_verification_token" character varying,
   "official_contact_email_verification_sent_at" timestamp with time zone,
   "verified_at" timestamp with time zone

--- a/packages/database/src/drizzle/schema.ts
+++ b/packages/database/src/drizzle/schema.ts
@@ -302,9 +302,6 @@ export const users_organizations = pgTable(
       .notNull(),
     verification_type: varchar(),
     has_been_greeted: boolean().default(false).notNull(),
-    needs_official_contact_email_verification: boolean()
-      .default(false)
-      .notNull(),
     official_contact_email_verification_token: varchar(),
     official_contact_email_verification_sent_at: timestamp({
       withTimezone: true,

--- a/packages/identite/src/repositories/organization/find-by-user-id.test.ts
+++ b/packages/identite/src/repositories/organization/find-by-user-id.test.ts
@@ -59,12 +59,12 @@ async function seed() {
 
   await pg.sql`
     INSERT INTO users_organizations
-      (user_id, organization_id, created_at, updated_at, is_external, verification_type, needs_official_contact_email_verification, official_contact_email_verification_token, official_contact_email_verification_sent_at, has_been_greeted)
+      (user_id, organization_id, created_at, updated_at, is_external, verification_type, official_contact_email_verification_token, official_contact_email_verification_sent_at, has_been_greeted)
     VALUES
-      (1, 1, '2023-01-25', '2024-02-20', false, 'necron', false, 'necron_token_1', '2023-01-26', true),
-      (1, 3, '2023-04-01', '2024-05-05', true, 'alliance', true, 'alliance_token_1', '2023-04-02', false),
-      (2, 2, '2023-03-01', '2024-04-01', false, 'necron', false, 'necron_token_2', '2023-03-02', true),
-      (6, 5, '2023-07-05', '2024-08-15', false, 'imperial', false, 'imperial_token_6', '2023-07-06', true)
+      (1, 1, '2023-01-25', '2024-02-20', false, 'necron', 'necron_token_1', '2023-01-26', true),
+      (1, 3, '2023-04-01', '2024-05-05', true, 'alliance', 'alliance_token_1', '2023-04-02', false),
+      (2, 2, '2023-03-01', '2024-04-01', false, 'necron', 'necron_token_2', '2023-03-02', true),
+      (6, 5, '2023-07-05', '2024-08-15', false, 'imperial', 'imperial_token_6', '2023-07-06', true)
     ;
   `;
 }

--- a/packages/identite/src/repositories/organization/find-by-user-id.test.ts.snapshot
+++ b/packages/identite/src/repositories/organization/find-by-user-id.test.ts.snapshot
@@ -28,7 +28,6 @@ exports[`findByUserIdFactory > should return multiple organizations when user ha
     "verification_type": "necron",
     "verified_at": null,
     "has_been_greeted": true,
-    "needs_official_contact_email_verification": false,
     "official_contact_email_verification_token": "necron_token_1",
     "official_contact_email_verification_sent_at": "2023-01-26T00:00:00.000Z"
   },
@@ -60,7 +59,6 @@ exports[`findByUserIdFactory > should return multiple organizations when user ha
     "verification_type": "alliance",
     "verified_at": null,
     "has_been_greeted": false,
-    "needs_official_contact_email_verification": true,
     "official_contact_email_verification_token": "alliance_token_1",
     "official_contact_email_verification_sent_at": "2023-04-02T00:00:00.000Z"
   }
@@ -97,7 +95,6 @@ exports[`findByUserIdFactory > should return single organization when user has o
     "verification_type": "imperial",
     "verified_at": null,
     "has_been_greeted": true,
-    "needs_official_contact_email_verification": false,
     "official_contact_email_verification_token": "imperial_token_6",
     "official_contact_email_verification_sent_at": "2023-07-06T00:00:00.000Z"
   }

--- a/packages/identite/src/repositories/organization/find-by-user-id.ts
+++ b/packages/identite/src/repositories/organization/find-by-user-id.ts
@@ -20,7 +20,6 @@ export function findByUserIdFactory({ pg }: DatabaseContext) {
           uo.verification_type,
           uo.verified_at,
           uo.has_been_greeted,
-          uo.needs_official_contact_email_verification,
           uo.official_contact_email_verification_token,
           uo.official_contact_email_verification_sent_at
         FROM organizations o

--- a/packages/identite/src/repositories/organization/get-users-by-organization.test.ts
+++ b/packages/identite/src/repositories/organization/get-users-by-organization.test.ts
@@ -32,9 +32,9 @@ describe("getUsersByOrganizationFactory", () => {
 
     await pg.sql`
       INSERT INTO users_organizations
-        (user_id, organization_id, created_at, updated_at, is_external, verification_type, needs_official_contact_email_verification, official_contact_email_verification_token, official_contact_email_verification_sent_at)
+        (user_id, organization_id, created_at, updated_at, is_external, verification_type, official_contact_email_verification_token, official_contact_email_verification_sent_at)
       VALUES
-        (1, 1, '4444-04-04', '4444-04-04', false, 'no_verification_means_available', false, null, null)
+        (1, 1, '4444-04-04', '4444-04-04', false, 'no_verification_means_available', null, null)
       ;
     `;
 

--- a/packages/identite/src/repositories/organization/get-users-by-organization.test.ts.snapshot
+++ b/packages/identite/src/repositories/organization/get-users-by-organization.test.ts.snapshot
@@ -30,7 +30,6 @@ exports[`getUsersByOrganizationFactory > should find users by organization id 1`
     "verification_type": "no_verification_means_available",
     "verified_at": null,
     "has_been_greeted": false,
-    "needs_official_contact_email_verification": false,
     "official_contact_email_verification_token": null,
     "official_contact_email_verification_sent_at": null
   }

--- a/packages/identite/src/repositories/organization/get-users-by-organization.ts
+++ b/packages/identite/src/repositories/organization/get-users-by-organization.ts
@@ -27,7 +27,6 @@ export function getUsersByOrganizationFactory({ pg }: DatabaseContext) {
           uo.verification_type,
           uo.verified_at,
           uo.has_been_greeted,
-          uo.needs_official_contact_email_verification,
           uo.official_contact_email_verification_token,
           uo.official_contact_email_verification_sent_at
         FROM users u

--- a/packages/identite/src/repositories/organization/link-user-to-organization.test.ts.snapshot
+++ b/packages/identite/src/repositories/organization/link-user-to-organization.test.ts.snapshot
@@ -7,7 +7,6 @@ exports[`linkUserToOrganizationFactory > should link user to organization 1`] = 
   "updated_at": "4444-04-04T00:00:00.000Z",
   "verification_type": null,
   "has_been_greeted": false,
-  "needs_official_contact_email_verification": false,
   "official_contact_email_verification_token": null,
   "official_contact_email_verification_sent_at": null,
   "verified_at": null
@@ -23,7 +22,6 @@ exports[`linkUserToOrganizationFactory > should mark a user as organization_diri
   "updated_at": "4444-04-04T00:00:00.000Z",
   "verification_type": "organization_dirigeant",
   "has_been_greeted": false,
-  "needs_official_contact_email_verification": false,
   "official_contact_email_verification_token": null,
   "official_contact_email_verification_sent_at": null,
   "verified_at": "4444-04-04T00:00:00.000Z"

--- a/packages/identite/src/repositories/organization/link-user-to-organization.ts
+++ b/packages/identite/src/repositories/organization/link-user-to-organization.ts
@@ -9,7 +9,6 @@ import type { QueryResult } from "pg";
 export function linkUserToOrganizationFactory({ pg }: DatabaseContext) {
   return async function linkUserToOrganization({
     is_external = false,
-    needs_official_contact_email_verification = false,
     organization_id,
     user_id,
     verification_type,
@@ -18,7 +17,6 @@ export function linkUserToOrganizationFactory({ pg }: DatabaseContext) {
       hashToPostgresParams<UserOrganizationLink>({
         created_at: new Date(),
         is_external,
-        needs_official_contact_email_verification,
         organization_id,
         updated_at: new Date(),
         user_id,

--- a/packages/identite/src/repositories/user/update-user-organization-link.test.ts
+++ b/packages/identite/src/repositories/user/update-user-organization-link.test.ts
@@ -32,9 +32,9 @@ suite("updateUserOrganizationLink", () => {
     `;
     await pg.sql`
       INSERT INTO users_organizations
-        (user_id, organization_id, created_at, updated_at, is_external, verification_type, needs_official_contact_email_verification, official_contact_email_verification_token, official_contact_email_verification_sent_at)
+        (user_id, organization_id, created_at, updated_at, is_external, verification_type, official_contact_email_verification_token, official_contact_email_verification_sent_at)
       VALUES
-        (1, 1, '4444-04-04', '4444-04-04', false, 'no_verification_means_available', false, null, null)
+        (1, 1, '4444-04-04', '4444-04-04', false, 'no_verification_means_available', null, null)
       ;
     `;
 

--- a/packages/identite/src/types/user-organization-link.ts
+++ b/packages/identite/src/types/user-organization-link.ts
@@ -1,19 +1,24 @@
 import { z } from "zod";
 
 export const UserOrganizationLinkVerificationTypeSchema = z.enum([
+  // This verification makes the associated identity eligible for eIDAS level 2 and above
+  "organization_dirigeant",
+  // These verifications make the associated identity eligible for eIDAS level 1
   "code_sent_to_official_contact_email",
   "domain",
   "imported_from_coop_mediation_numerique",
   "imported_from_inclusion_connect",
   "in_liste_dirigeants_rna",
   "in_liste_dirigeants_rne",
-  "pending_organization_dirigeant",
+  "official_contact_email",
+  "proof_received",
+  // These verifications make the associated identity eligible for eIDAS level 0
   "no_validation_means_available",
   "no_verification_means_for_entreprise_unipersonnelle",
   "no_verification_means_for_small_association",
-  "official_contact_email",
-  "organization_dirigeant",
-  "proof_received",
+  // These verifications indicate that the linked identity has not yet been confirmed as part of the organization
+  "pending_code_sent_to_official_contact_email",
+  "pending_organization_dirigeant",
   // Used in the sandbox environment to bypass the verification process
   "bypassed",
 ]);
@@ -30,7 +35,6 @@ export const BaseUserOrganizationLinkSchema = z.object({
   // updated when verification_type is changed
   verified_at: z.date().or(z.literal(null)),
   has_been_greeted: z.boolean(),
-  needs_official_contact_email_verification: z.boolean(),
   official_contact_email_verification_token: z.string().nullable(),
   official_contact_email_verification_sent_at: z.date().nullable(),
 });
@@ -63,7 +67,6 @@ export const InsertUserOrganizationLinkSchema = UserOrganizationLinkSchema.pick(
 ).merge(
   UserOrganizationLinkSchema.pick({
     is_external: true,
-    needs_official_contact_email_verification: true,
   }).partial(),
 );
 

--- a/scripts/create-anonymized-copy-of-database.sh
+++ b/scripts/create-anonymized-copy-of-database.sh
@@ -183,7 +183,6 @@ SELECT
 	updated_at,
 	verification_type,
 	has_been_greeted,
-	needs_official_contact_email_verification,
 	'**********' as official_contact_email_verification_token,
 	official_contact_email_verification_sent_at,
 	verified_at

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -311,8 +311,7 @@ export const joinOrganization = async ({
       return await linkUserToOrganization({
         organization_id,
         user_id,
-        verification_type: "code_sent_to_official_contact_email",
-        needs_official_contact_email_verification: true,
+        verification_type: "pending_code_sent_to_official_contact_email",
       });
     }
   }
@@ -338,8 +337,7 @@ export const joinOrganization = async ({
       return await linkUserToOrganization({
         organization_id,
         user_id,
-        verification_type: "code_sent_to_official_contact_email",
-        needs_official_contact_email_verification: true,
+        verification_type: "pending_code_sent_to_official_contact_email",
       });
     }
   }

--- a/src/managers/organization/official-contact-email-verification.ts
+++ b/src/managers/organization/official-contact-email-verification.ts
@@ -47,12 +47,10 @@ export const sendOfficialContactEmailVerificationEmail = async ({
     throw new NotFoundError();
   }
 
-  const {
-    needs_official_contact_email_verification,
-    official_contact_email_verification_sent_at,
-  } = user;
+  const { verification_type, official_contact_email_verification_sent_at } =
+    user;
 
-  if (!needs_official_contact_email_verification) {
+  if (verification_type !== "pending_code_sent_to_official_contact_email") {
     throw new OfficialContactEmailVerificationNotNeededError();
   }
 
@@ -135,7 +133,11 @@ export const verifyOfficialContactEmailToken = async ({
   const organization = await findOrganizationById(organization_id);
 
   // The user should be in the organization already
-  if (isEmpty(user) || isEmpty(organization)) {
+  if (
+    isEmpty(user) ||
+    isEmpty(organization) ||
+    user.verification_type !== "pending_code_sent_to_official_contact_email"
+  ) {
     throw new NotFoundError();
   }
 
@@ -158,7 +160,7 @@ export const verifyOfficialContactEmailToken = async ({
   }
 
   return await updateUserOrganizationLink(organization_id, user_id, {
-    needs_official_contact_email_verification: false,
+    verification_type: "code_sent_to_official_contact_email",
     official_contact_email_verification_token: null,
     official_contact_email_verification_sent_at: null,
   });

--- a/src/managers/session/authenticated.ts
+++ b/src/managers/session/authenticated.ts
@@ -273,10 +273,12 @@ export async function getCurrentIAL(req: Request) {
   const hasConsistencyCheckVerificationType = [
     "code_sent_to_official_contact_email",
     "domain",
-    "imported_from_inclusion_connect",
     "imported_from_coop_mediation_numerique",
+    "imported_from_inclusion_connect",
     "in_liste_dirigeants_rna",
+    "in_liste_dirigeants_rne",
     "official_contact_email",
+    "proof_received",
     "bypassed",
   ].includes(link?.verification_type ?? "");
 

--- a/src/middlewares/navigation-guards.ts
+++ b/src/middlewares/navigation-guards.ts
@@ -537,15 +537,17 @@ export const requireUserHasNoPendingOfficialContactEmailVerification: Navigation
 
         organizationThatNeedsOfficialContactEmailVerification =
           userOrganisations.find(
-            ({ id, needs_official_contact_email_verification }) =>
-              needs_official_contact_email_verification &&
+            ({ id, verification_type }) =>
+              verification_type ===
+                "pending_code_sent_to_official_contact_email" &&
               id === selectedOrganizationId,
           );
       } else {
         organizationThatNeedsOfficialContactEmailVerification =
           userOrganisations.find(
-            ({ needs_official_contact_email_verification }) =>
-              needs_official_contact_email_verification,
+            ({ verification_type }) =>
+              verification_type ===
+              "pending_code_sent_to_official_contact_email",
           );
       }
 

--- a/src/repositories/organization/getters.ts
+++ b/src/repositories/organization/getters.ts
@@ -97,7 +97,6 @@ SELECT
   verification_type,
   verified_at,
   has_been_greeted,
-  needs_official_contact_email_verification,
   official_contact_email_verification_token,
   official_contact_email_verification_sent_at
 FROM users_organizations


### PR DESCRIPTION
**Problem**

We currently have two ways of representing a temporary user–organization link in the application.

* *Certif dirigeant* is represented using a temporary link type.
* The code sent to the official contact is represented using a boolean value that complements the link type.

This results in two different mechanisms to model temporary verification types, whereas we should have a single, extensible approach.

**Proposal**

* Introduce a new temporary status: `pending_code_sent_to_official_contact_email`, which triggers sending the verification code.
* Remove the boolean value so that the verification status can be understood by reading the link type alone.