### PR TITLE
💬 Update the wording on the 'Rejected moderation' page

### DIFF
--- a/src/views/user/moderation-rejected.ejs
+++ b/src/views/user/moderation-rejected.ejs
@@ -7,7 +7,8 @@
       <% if (allowEditing) { %>
         Corrigez l'information pour que votre demande soit de nouveau étudiée.
       <% } else { %>
-        Nous n’avons pas pu établir de lien entre l’organisation et vous. Contactez-nous si vous avez d’autres éléments à nous fournir.
+        Nous n’avons pas pu établir de lien entre l’organisation et vous.
+        Nous vous avons envoyé un email de refus. Merci d'y répondre si vous avez d'autres éléments à nous fournir.
       <% } %>
     </p>
   </div>


### PR DESCRIPTION
We must ensure that an email is sent when a user's request is denied. We must also verify that the email address is not « nepasrepondre@proconnect.gouv.fr ». 