### PR TITLE
💄 make peer dependencies optional in identite package

### DIFF
--- a/.changeset/thick-trees-sort.md
+++ b/.changeset/thick-trees-sort.md
@@ -1,0 +1,5 @@
+---
+"@proconnect-gouv/proconnect.identite": patch
+---
+
+🐛 Les peerDependencies sont optionnelles et le devtools.typescript est retiré des dépendances

--- a/packages/identite/package.json
+++ b/packages/identite/package.json
@@ -68,9 +68,25 @@
     "@proconnect-gouv/proconnect.annuaire_entreprises": "^1.1.4",
     "@proconnect-gouv/proconnect.api_entreprise": "^2.0.0",
     "@proconnect-gouv/proconnect.core": "^1.0.0",
-    "@proconnect-gouv/proconnect.devtools.typescript": "1.0.0",
     "@proconnect-gouv/proconnect.insee": "^2.0.0",
     "@proconnect-gouv/proconnect.registre_national_entreprises": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@proconnect-gouv/proconnect.annuaire_entreprises": {
+      "optional": true
+    },
+    "@proconnect-gouv/proconnect.api_entreprise": {
+      "optional": true
+    },
+    "@proconnect-gouv/proconnect.core": {
+      "optional": true
+    },
+    "@proconnect-gouv/proconnect.insee": {
+      "optional": true
+    },
+    "@proconnect-gouv/proconnect.registre_national_entreprises": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
- Remove devtools.typescript from dependencies
- Add peerDependenciesMeta to mark all peer dependencies as optional
- Allows users to install only required peer dependencies