### PR TITLE
⚡️ fix memory leak in request

### DIFF
--- a/.changeset/floppy-rivers-report.md
+++ b/.changeset/floppy-rivers-report.md
@@ -1,0 +1,5 @@
+---
+"@proconnect-gouv/proconnect.debounce": patch
+---
+
+correction de memory leak

--- a/packages/debounce/src/api/request.ts
+++ b/packages/debounce/src/api/request.ts
@@ -15,7 +15,8 @@ async function request<responseT>(
       signal: AbortSignal.timeout(options?.timeout ?? 30_000),
     });
     if (!res.ok) {
-      throw new FetchError(res.statusText);
+      const response = await res.text();
+      throw new FetchError(response);
     }
     const contentType = res.headers.get("content-type");
     if (contentType?.includes("application/json")) {
@@ -23,6 +24,9 @@ async function request<responseT>(
     }
     return { data: (await res.text()) as unknown as responseT };
   } catch (error) {
+    if (error instanceof FetchError) {
+      throw error;
+    }
     throw new FetchError(
       error instanceof Error ? error.message : String(error),
     );

--- a/src/connectors/request.ts
+++ b/src/connectors/request.ts
@@ -8,18 +8,15 @@ async function request<responseT>(
     timeout?: number;
   },
 ): Promise<{ data: responseT }> {
-  const timeout = options?.timeout ?? 30000;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
-
   try {
     const res = await fetch(url, {
       headers: options?.headers,
       method: options?.method,
-      signal: controller.signal,
+      signal: AbortSignal.timeout(options?.timeout ?? 30_000),
     });
     if (!res.ok) {
-      throw new FetchError(res.statusText);
+      const response = await res.text();
+      throw new FetchError(response);
     }
     const contentType = res.headers.get("content-type");
     if (contentType?.includes("application/json")) {
@@ -27,11 +24,12 @@ async function request<responseT>(
     }
     return { data: (await res.text()) as unknown as responseT };
   } catch (error) {
+    if (error instanceof FetchError) {
+      throw error;
+    }
     throw new FetchError(
       error instanceof Error ? error.message : String(error),
     );
-  } finally {
-    clearTimeout(timeoutId);
   }
 }
 


### PR DESCRIPTION
The issue: unconsumed response bodies leak socket connections. When a request returns non-2xx status, the body wasn't being read, so the connection stayed open indefinitely. With enough failed requests, you exhaust the heap.

Key differences from axios:

Axios automatically consumes response bodies and cleans up connections
Native fetch requires you to explicitly consume the body with .json(), .text(), or .arrayBuffer() before the connection is freed
The fix ensures all response bodies are consumed before throwing errors, forcing Node.js to properly clean up and reuse connections.