### PR TITLE
🔧 Use before hook for db seed

### DIFF
--- a/cypress/e2e/activate_totp/index.cy.ts
+++ b/cypress/e2e/activate_totp/index.cy.ts
@@ -1,7 +1,5 @@
 describe("add 2fa authentication", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should add 2fa authentication on account user", function () {
     cy.visit("/connection-and-account");

--- a/cypress/e2e/broken_standard_client/index.cy.ts
+++ b/cypress/e2e/broken_standard_client/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("sign-in from broken client", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should fail with invalid redirect uri", function () {
     cy.visit("http://localhost:4000");

--- a/cypress/e2e/connect_franceconnect_account/index.cy.ts
+++ b/cypress/e2e/connect_franceconnect_account/index.cy.ts
@@ -1,7 +1,5 @@
 describe("Connect FranceConnect account", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("Should update personal information with FranceConnect data", function () {
     cy.visit("/personal-information");

--- a/cypress/e2e/delete_account/index.cy.ts
+++ b/cypress/e2e/delete_account/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("delete account", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should delete account", function () {
     cy.visit("/connection-and-account");

--- a/cypress/e2e/join_collectivite_territoriale_free_contact_domain/index.cy.ts
+++ b/cypress/e2e/join_collectivite_territoriale_free_contact_domain/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("join collectivité territoriale with free contact domain", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should directly accept the same email address", function () {
     cy.visit("/users/join-organization");

--- a/cypress/e2e/join_collectivite_territoriale_official_contact_domain/index.cy.ts
+++ b/cypress/e2e/join_collectivite_territoriale_official_contact_domain/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("join collectivité territoriale with official contact domain", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should directly accept the same domain address", function () {
     cy.visit("/users/join-organization");

--- a/cypress/e2e/join_must_confirm/index.cy.ts
+++ b/cypress/e2e/join_must_confirm/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("join organizations", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("join big company with free email provider", function () {
     cy.visit("/users/start-sign-in");

--- a/cypress/e2e/join_org_with_trackdechets_domain/index.cy.ts
+++ b/cypress/e2e/join_org_with_trackdechets_domain/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("join organizations", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("join suggested organisation", function () {
     cy.visit("/users/join-organization");

--- a/cypress/e2e/join_with_code_sent_to_official_contact_email/index.cy.ts
+++ b/cypress/e2e/join_with_code_sent_to_official_contact_email/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("join collectivité territoriale with code send to official contact email", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should send a code challenge for user with a private email domain", function () {
     cy.visit("/users/join-organization");

--- a/cypress/e2e/join_with_code_sent_to_official_educ_nat_contact_email/index.cy.ts
+++ b/cypress/e2e/join_with_code_sent_to_official_educ_nat_contact_email/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("join organizations", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("join collectivité territoriale with code send to official contact email", function () {
     cy.visit("/users/join-organization");

--- a/cypress/e2e/join_with_gouv_domain/index.cy.ts
+++ b/cypress/e2e/join_with_gouv_domain/index.cy.ts
@@ -1,8 +1,6 @@
 //
 
-it("should seed the database once", function () {
-  cy.seed();
-});
+before(cy.seed);
 
 describe("join with gouv.fr domain", () => {
   beforeEach(() => {

--- a/cypress/e2e/join_with_official_contact_email/index.cy.ts
+++ b/cypress/e2e/join_with_official_contact_email/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("join organizations", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("join collectivité territoriale with official contact email", function () {
     cy.visit("/users/join-organization");

--- a/cypress/e2e/rate_limit_by_email/index.cy.ts
+++ b/cypress/e2e/rate_limit_by_email/index.cy.ts
@@ -1,7 +1,5 @@
 describe("trigger rate limit by email", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should trigger totp rate limiting", function () {
     cy.visit("/users/start-sign-in");

--- a/cypress/e2e/reauthenticate_on_admin_page/index.cy.ts
+++ b/cypress/e2e/reauthenticate_on_admin_page/index.cy.ts
@@ -1,7 +1,5 @@
 describe("force recent connexion + 2FA on admin pages", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should be redirected after long connexion", function () {
     cy.visit("/");

--- a/cypress/e2e/redirect_after_session_expiration/index.cy.ts
+++ b/cypress/e2e/redirect_after_session_expiration/index.cy.ts
@@ -1,7 +1,5 @@
 describe("redirect after session expiration", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should be redirected to organization management page", function () {
     cy.visit("/manage-organizations");

--- a/cypress/e2e/reset_password/index.cy.ts
+++ b/cypress/e2e/reset_password/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("reset password", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should reset password then sign-in", function () {
     // Visit the signup page

--- a/cypress/e2e/set_info_after_account_provisioning/index.cy.ts
+++ b/cypress/e2e/set_info_after_account_provisioning/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("set info after account provisioning", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should show InclusionConnect welcome page on first visit", function () {
     // Visit the signup page

--- a/cypress/e2e/signin_from_proconnect_federation_client/index.cy.ts
+++ b/cypress/e2e/signin_from_proconnect_federation_client/index.cy.ts
@@ -1,8 +1,6 @@
 //
 
-it("should seed the database once", function () {
-  cy.seed();
-});
+before(cy.seed);
 
 describe("sign-in from proconnect federation client", () => {
   it("should sign-in", () => {

--- a/cypress/e2e/signin_from_standard_client/index.cy.ts
+++ b/cypress/e2e/signin_from_standard_client/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("sign-in from standard client", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should sign-in without org selection when having only one organization", function () {
     cy.visit("http://localhost:4000");

--- a/cypress/e2e/signin_with_email_verification/index.cy.ts
+++ b/cypress/e2e/signin_with_email_verification/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("sign-in with email verification renewal", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should sign-in with email verification needed", () => {
     cy.visit("/users/start-sign-in");

--- a/cypress/e2e/signin_with_email_verification_renewal/index.cy.ts
+++ b/cypress/e2e/signin_with_email_verification_renewal/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("sign-in with email verification renewal", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should sign-in with email verification needed", () => {
     // Visit the signup page

--- a/cypress/e2e/signin_with_totp/index.cy.ts
+++ b/cypress/e2e/signin_with_totp/index.cy.ts
@@ -1,7 +1,5 @@
 describe("sign-in with TOTP on untrusted browser", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should sign-in with password and TOTP", function () {
     cy.visit("http://localhost:4000");

--- a/cypress/e2e/signup_entreprise_unipersonnelle/index.cy.ts
+++ b/cypress/e2e/signup_entreprise_unipersonnelle/index.cy.ts
@@ -1,9 +1,7 @@
 //
 
 describe("Signup into new entreprise unipersonnelle", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("creates a user", function () {
     cy.origin("http://localhost:4000", () => {

--- a/cypress/e2e/use_extra_param_sp_name/index.cy.ts
+++ b/cypress/e2e/use_extra_param_sp_name/index.cy.ts
@@ -1,7 +1,5 @@
 describe("display sp name", () => {
-  it("should seed the database once", function () {
-    cy.seed();
-  });
+  before(cy.seed);
 
   it("should display sp name on mfa choice page", function () {
     cy.visit("http://localhost:4001/");


### PR DESCRIPTION
We are changing the way we seed the database in end-to-end tests.

Old version:
```
it(‘should seed the database once’, function () {
    cy.seed();
});
```

New version: 
`before(cy.seed);`