### PR TITLE
✏️  replace the reason for rejection with a message advising the recipient to check the email they have received

### DIFF
--- a/cypress/e2e/join_org_with_rejected_moderation/index.cy.ts
+++ b/cypress/e2e/join_org_with_rejected_moderation/index.cy.ts
@@ -16,9 +16,11 @@ describe("join organization with rejected moderation", () => {
 
     cy.title().should("include", "Demande refusée - ProConnect");
     cy.contains("Demande refusée");
-    cy.contains("Motif : Nom de domaine introuvable");
     cy.contains(
       "Nous n’avons pas pu établir de lien entre l’organisation et vous.",
+    );
+    cy.contains(
+      "Pour plus d'information, consultez le mail que nous vous avons envoyé.",
     );
     cy.contains("Changer d'organisation").click();
 
@@ -46,7 +48,9 @@ describe("join organization with rejected moderation", () => {
 
     cy.title().should("include", "Informations à corriger - ProConnect");
     cy.contains("Modifications demandées");
-    cy.contains("Motif : Inversion Nom et Prénom");
+    cy.contains(
+      "Pour plus d'information, consultez le mail que nous vous avons envoyé.",
+    );
     cy.getByLabel("Corriger le nom").click();
 
     cy.title().should("include", "Renseigner votre identité - ProConnect");
@@ -78,9 +82,11 @@ describe("join organization with rejected moderation", () => {
 
     cy.title().should("include", "Demande refusée - ProConnect");
     cy.contains("Demande refusée");
-    cy.contains("Motif : Raison non spécifiée");
     cy.contains(
       "Nous n’avons pas pu établir de lien entre l’organisation et vous.",
+    );
+    cy.contains(
+      "Pour plus d'information, consultez le mail que nous vous avons envoyé.",
     );
     cy.getByLabel("Changer d’adresse email").click();
 

--- a/src/views/user/moderation-rejected.ejs
+++ b/src/views/user/moderation-rejected.ejs
@@ -2,14 +2,14 @@
   <h1 class="fr-h5"><%= allowEditing ? "Modifications demandées" : "Demande refusée ⛔" %></h1>
   <hr class="hr-personalized-step-three fr-mb-3w">
   <div>
-    <p>
-      <b> Motif : <%= rejectionReason %> <br /> </b>
+    <p class="fr-mb-2w">
       <% if (allowEditing) { %>
         Corrigez l'information pour que votre demande soit de nouveau étudiée.
       <% } else { %>
         Nous n’avons pas pu établir de lien entre l’organisation et vous. Contactez-nous si vous avez d’autres éléments à nous fournir.
       <% } %>
     </p>
+    <p><b>Pour plus d'information, consultez le mail que nous vous avons envoyé.</b></p>
   </div>
 </div>
 


### PR DESCRIPTION
I kept the `rejectionReason` template variable as I'll be using it in upcoming PRs — is that okay with you @rdubigny?

I took the liberty of rephrasing the sentence "Consultez l'email que vous avez reçu pour plus d'information" with : "Pour plus d'information, consultez le mail que nous vous avons envoyé." 

Also, I think the sentence "Corrigez l'information pour que votre demande soit de nouveau étudiée." is a bit unclear as the user doesn't know which specific information we're referring to.

cc @rdubigny @renardpal 