### PR TITLE
🐛 join: auto-validate users with official_contact domain

### DIFF
--- a/.changeset/plenty-taxis-stick.md
+++ b/.changeset/plenty-taxis-stick.md
@@ -1,0 +1,18 @@
+---
+"@proconnect-gouv/proconnect.identite": minor
+---
+
+♻️ Les exports `*Types` sont renommés selon une convention uniforme : tableaux `as const` → `*Values`, schémas Zod → `*Enum`.
+
+| Avant                                   | Après                                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------------- |
+| `LinkTypes`                             | `LinkEnum`                                                                      |
+| `StrongLinkTypes`                       | `StrongLinkValues`                                                              |
+| `WeakLinkTypes`                         | `WeakLinkValues`                                                                |
+| `SuperWeakLinkTypes`                    | `SuperWeakLinkValues` + `SuperWeakLinkEnum`                                     |
+| `UnverifiedLinkTypes`                   | `UnverifiedLinkValues` + `UnverifiedLinkEnum`                                   |
+| `EmailDomainApprovedVerificationTypes`  | `EmailDomainApprovedVerificationEnum`                                           |
+| `EmailDomainPendingVerificationTypes`   | `EmailDomainPendingVerificationValues` + `EmailDomainPendingVerificationEnum`   |
+| `EmailDomainRejectedVerificationTypes`  | `EmailDomainRejectedVerificationValues` + `EmailDomainRejectedVerificationEnum` |
+| `EmailDomainNoPendingVerificationTypes` | `EmailDomainNoPendingVerificationEnum`                                          |
+| `EmailDomainVerificationTypes`          | `EmailDomainVerificationEnum`                                                   |

--- a/packages/identite/src/managers/organization/mark-domain-as-verified.ts
+++ b/packages/identite/src/managers/organization/mark-domain-as-verified.ts
@@ -5,7 +5,7 @@ import { NotFoundError } from "#src/errors";
 import { assignUserVerificationTypeToDomainFactory } from "#src/managers/user";
 import {
   type EmailDomainApprovedVerificationType,
-  EmailDomainApprovedVerificationTypes,
+  EmailDomainApprovedVerificationValues,
   type EmailDomainNoPendingVerificationType,
   EmailDomainPendingVerificationTypes,
   type EmailDomainRejectedVerificationType,
@@ -43,7 +43,7 @@ export function markDomainAsVerifiedFactory(context: Context) {
 
     return match(domain_verification_type)
       .with(
-        ...EmailDomainApprovedVerificationTypes,
+        ...EmailDomainApprovedVerificationValues,
         async (approved_verification_type) => {
           await assignUserVerificationTypeToDomain(organization_id, domain);
           return markDomainAsApproved({
@@ -78,7 +78,7 @@ export function markDomainAsVerifiedFactory(context: Context) {
       organization_id,
       domain,
       domain_verification_types: [
-        ...EmailDomainApprovedVerificationTypes,
+        ...EmailDomainApprovedVerificationValues,
         ...EmailDomainPendingVerificationTypes,
       ],
     });

--- a/packages/identite/src/managers/organization/mark-domain-as-verified.ts
+++ b/packages/identite/src/managers/organization/mark-domain-as-verified.ts
@@ -7,9 +7,9 @@ import {
   type EmailDomainApprovedVerificationType,
   EmailDomainApprovedVerificationValues,
   type EmailDomainNoPendingVerificationType,
-  EmailDomainPendingVerificationTypes,
+  EmailDomainPendingVerificationValues,
   type EmailDomainRejectedVerificationType,
-  EmailDomainRejectedVerificationTypes,
+  EmailDomainRejectedVerificationValues,
   type EmailDomainVerificationType,
 } from "#src/types";
 
@@ -54,7 +54,7 @@ export function markDomainAsVerifiedFactory(context: Context) {
         },
       )
       .with(
-        ...EmailDomainRejectedVerificationTypes,
+        ...EmailDomainRejectedVerificationValues,
         (rejected_verification_type) =>
           markDomainAsRejected({
             organization_id,
@@ -79,7 +79,7 @@ export function markDomainAsVerifiedFactory(context: Context) {
       domain,
       domain_verification_types: [
         ...EmailDomainApprovedVerificationValues,
-        ...EmailDomainPendingVerificationTypes,
+        ...EmailDomainPendingVerificationValues,
       ],
     });
     return email_domains.addDomain({
@@ -103,8 +103,8 @@ export function markDomainAsVerifiedFactory(context: Context) {
       organization_id,
       domain,
       domain_verification_types: [
-        ...EmailDomainPendingVerificationTypes,
-        ...EmailDomainRejectedVerificationTypes,
+        ...EmailDomainPendingVerificationValues,
+        ...EmailDomainRejectedVerificationValues,
       ],
     });
     return email_domains.addDomain({

--- a/packages/identite/src/managers/user/assign-user-verification-type-to-domain.ts
+++ b/packages/identite/src/managers/user/assign-user-verification-type-to-domain.ts
@@ -1,9 +1,8 @@
 //
 
 import type { Context } from "#src/connectors";
-import { LinkTypes, SuperWeakLinkTypes, UnverifiedLinkTypes } from "#src/types";
+import { LinkEnum, SuperWeakLinkEnum, UnverifiedLinkEnum } from "#src/types";
 import { getEmailDomain } from "@proconnect-gouv/proconnect.core/services/email";
-import { match } from "ts-pattern";
 
 //
 
@@ -22,12 +21,11 @@ export function assignUserVerificationTypeToDomainFactory({
           const userDomain = getEmailDomain(email);
           if (
             userDomain === domain &&
-            match(link_verification_type)
-              .with(...UnverifiedLinkTypes, ...SuperWeakLinkTypes, () => true)
-              .otherwise(() => false)
+            (UnverifiedLinkEnum.safeParse(link_verification_type).success ||
+              SuperWeakLinkEnum.safeParse(link_verification_type).success)
           ) {
             return users_organizations.update(organization_id, id, {
-              verification_type: LinkTypes.enum.domain,
+              verification_type: LinkEnum.enum.domain,
             });
           }
 

--- a/packages/identite/src/repositories/organization/link-user-to-organization.test.ts
+++ b/packages/identite/src/repositories/organization/link-user-to-organization.test.ts
@@ -1,4 +1,4 @@
-import { LinkTypes } from "#src/types";
+import { LinkEnum } from "#src/types";
 import { emptyDatabase, migrate, pg } from "#testing";
 import { before, beforeEach, mock, suite, test } from "node:test";
 import { linkUserToOrganizationFactory } from "./link-user-to-organization.js";
@@ -33,7 +33,7 @@ suite("linkUserToOrganizationFactory", () => {
     const userOrganizationLink = await linkUserToOrganization({
       organization_id: 1,
       user_id: 1,
-      verification_type: LinkTypes.enum.domain_not_verified_yet,
+      verification_type: LinkEnum.enum.domain_not_verified_yet,
     });
 
     t.assert.snapshot(userOrganizationLink);
@@ -58,7 +58,7 @@ suite("linkUserToOrganizationFactory", () => {
     const userOrganizationLink = await linkUserToOrganization({
       organization_id: 1,
       user_id: 1,
-      verification_type: LinkTypes.enum.organization_dirigeant,
+      verification_type: LinkEnum.enum.organization_dirigeant,
     });
 
     t.assert.snapshot(userOrganizationLink);

--- a/packages/identite/src/types/email-domain.ts
+++ b/packages/identite/src/types/email-domain.ts
@@ -7,56 +7,64 @@ export const EmailDomainApprovedVerificationValues = [
   "external", // domain used by external employees (eg. ext.numerique.gouv.fr)
 ] as const;
 
-export const EmailDomainApprovedVerificationTypes = z.enum(
+export const EmailDomainApprovedVerificationEnum = z.enum(
   EmailDomainApprovedVerificationValues,
 );
 
 export type EmailDomainApprovedVerificationType = z.output<
-  typeof EmailDomainApprovedVerificationTypes
+  typeof EmailDomainApprovedVerificationEnum
 >;
 
 // domain is not verified, but users are still permitted to use it
-export const EmailDomainPendingVerificationTypes = [
+export const EmailDomainPendingVerificationValues = [
   "not_verified_yet",
 ] as const;
 
+export const EmailDomainPendingVerificationEnum = z.enum(
+  EmailDomainPendingVerificationValues,
+);
+
 export type EmailDomainPendingVerificationType = z.output<
-  typeof EmailDomainPendingVerificationTypes
+  typeof EmailDomainPendingVerificationEnum
 >;
 
-export const EmailDomainRejectedVerificationTypes = [
+export const EmailDomainRejectedVerificationValues = [
   "blacklisted", // unused
   "refused",
 ] as const;
 
+export const EmailDomainRejectedVerificationEnum = z.enum(
+  EmailDomainRejectedVerificationValues,
+);
+
 export type EmailDomainRejectedVerificationType = z.output<
-  typeof EmailDomainRejectedVerificationTypes
+  typeof EmailDomainRejectedVerificationEnum
 >;
 
-export const EmailDomainNoPendingVerificationTypes = z.enum([
+export const EmailDomainNoPendingVerificationEnum = z.enum([
   ...EmailDomainApprovedVerificationValues,
-  ...EmailDomainRejectedVerificationTypes,
+  ...EmailDomainRejectedVerificationValues,
 ]);
 
 export type EmailDomainNoPendingVerificationType = z.output<
-  typeof EmailDomainNoPendingVerificationTypes
+  typeof EmailDomainNoPendingVerificationEnum
 >;
 
-export const EmailDomainVerificationTypes = z.enum([
+export const EmailDomainVerificationEnum = z.enum([
   ...EmailDomainApprovedVerificationValues,
-  ...EmailDomainPendingVerificationTypes,
-  ...EmailDomainRejectedVerificationTypes,
+  ...EmailDomainPendingVerificationValues,
+  ...EmailDomainRejectedVerificationValues,
 ]);
 
 export type EmailDomainVerificationType = z.output<
-  typeof EmailDomainVerificationTypes
+  typeof EmailDomainVerificationEnum
 >;
 
 export const EmailDomainSchema = z.object({
   id: z.number(),
   organization_id: z.number(),
   domain: z.string(),
-  verification_type: EmailDomainVerificationTypes,
+  verification_type: EmailDomainVerificationEnum,
   // Unused.
   can_be_suggested: z.boolean(),
   // Can be updated when verification_type changes.

--- a/packages/identite/src/types/email-domain.ts
+++ b/packages/identite/src/types/email-domain.ts
@@ -1,11 +1,15 @@
 import { z } from "zod";
 
-export const EmailDomainApprovedVerificationTypes = [
+export const EmailDomainApprovedVerificationValues = [
   "official_contact",
   "trackdechets_postal_mail",
   "verified",
   "external", // domain used by external employees (eg. ext.numerique.gouv.fr)
 ] as const;
+
+export const EmailDomainApprovedVerificationTypes = z.enum(
+  EmailDomainApprovedVerificationValues,
+);
 
 export type EmailDomainApprovedVerificationType = z.output<
   typeof EmailDomainApprovedVerificationTypes
@@ -30,7 +34,7 @@ export type EmailDomainRejectedVerificationType = z.output<
 >;
 
 export const EmailDomainNoPendingVerificationTypes = z.enum([
-  ...EmailDomainApprovedVerificationTypes,
+  ...EmailDomainApprovedVerificationValues,
   ...EmailDomainRejectedVerificationTypes,
 ]);
 
@@ -39,7 +43,7 @@ export type EmailDomainNoPendingVerificationType = z.output<
 >;
 
 export const EmailDomainVerificationTypes = z.enum([
-  ...EmailDomainApprovedVerificationTypes,
+  ...EmailDomainApprovedVerificationValues,
   ...EmailDomainPendingVerificationTypes,
   ...EmailDomainRejectedVerificationTypes,
 ]);

--- a/packages/identite/src/types/user-organization-link.ts
+++ b/packages/identite/src/types/user-organization-link.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
-export const StrongLinkTypes = ["organization_dirigeant"] as const;
+export const StrongLinkValues = ["organization_dirigeant"] as const;
 
-export const WeakLinkTypes = [
+export const WeakLinkValues = [
   "code_sent_to_official_contact_email",
   "domain",
   "imported_from_coop_mediation_numerique",
@@ -17,31 +17,40 @@ export const WeakLinkTypes = [
   "bypassed",
 ] as const;
 
-// This link type should be considered as unverified.
+// This link value should be considered as unverified.
 // However, doing so would trigger a FranceConnect authentication requirement for the user.
 // Users shouldn't face inconvenience while waiting for domain review completion.
 // Instead, we should remove these unverified domains and then eliminate this special case from the codebase.
-export const SuperWeakLinkTypes = ["domain_not_verified_yet"] as const;
+export const SuperWeakLinkValues = ["domain_not_verified_yet"] as const;
 
-const VerifiedLinkTypes = [
-  ...StrongLinkTypes,
-  ...WeakLinkTypes,
-  ...SuperWeakLinkTypes,
+export const SuperWeakLinkEnum = z.enum(SuperWeakLinkValues);
+
+export const VerifiedLinkValues = [
+  ...StrongLinkValues,
+  ...WeakLinkValues,
+  ...SuperWeakLinkValues,
 ] as const;
 
-export const UnverifiedLinkTypes = [
+export const VerifiedLinkEnum = z.enum(VerifiedLinkValues);
+
+export const UnverifiedLinkValues = [
   "no_validation_means_available",
   "no_verification_means_for_entreprise_unipersonnelle",
   "no_verification_means_for_small_association",
 ] as const;
 
-export const LinkTypes = z.enum([...VerifiedLinkTypes, ...UnverifiedLinkTypes]);
+export const UnverifiedLinkEnum = z.enum(UnverifiedLinkValues);
 
-export type LinkType = z.output<typeof LinkTypes>;
+export const LinkEnum = z.enum([
+  ...VerifiedLinkValues,
+  ...UnverifiedLinkValues,
+]);
+
+export type LinkType = z.output<typeof LinkEnum>;
 
 export const BaseUserOrganizationLinkSchema = z.object({
   is_external: z.boolean(),
-  verification_type: LinkTypes,
+  verification_type: LinkEnum,
   // updated when verification_type is changed
   verified_at: z.date().or(z.literal(null)),
   has_been_greeted: z.boolean(),

--- a/scripts/import-accounts-coop.ts
+++ b/scripts/import-accounts-coop.ts
@@ -5,7 +5,7 @@ import {
   isPhoneNumberValid,
   isSiretValid,
 } from "@proconnect-gouv/proconnect.core/security";
-import { LinkTypes } from "@proconnect-gouv/proconnect.identite/types";
+import { LinkEnum } from "@proconnect-gouv/proconnect.identite/types";
 import { parse, stringify, transform } from "csv";
 import fs from "fs";
 import { isEmpty, isString, some, toInteger } from "lodash-es";
@@ -197,7 +197,7 @@ const maxInseeCallRateInMs = rateInMsFromArgs !== 0 ? rateInMsFromArgs : 125;
               organization_id: organization.id,
               user_id: user.id,
               verification_type:
-                LinkTypes.enum.imported_from_coop_mediation_numerique,
+                LinkEnum.enum.imported_from_coop_mediation_numerique,
             });
           }
         } catch (error) {

--- a/scripts/import-accounts.ts
+++ b/scripts/import-accounts.ts
@@ -4,7 +4,7 @@ import {
   isNameValid,
   isSiretValid,
 } from "@proconnect-gouv/proconnect.core/security";
-import { LinkTypes } from "@proconnect-gouv/proconnect.identite/types";
+import { LinkEnum } from "@proconnect-gouv/proconnect.identite/types";
 import { parse, stringify, transform } from "csv";
 import fs from "fs";
 import { isEmpty, isString, some, toInteger } from "lodash-es";
@@ -181,7 +181,7 @@ const maxInseeCallRateInMs = rateInMsFromArgs !== 0 ? rateInMsFromArgs : 125;
                 organization_id: organization.id,
                 user_id: user.id,
                 verification_type:
-                  LinkTypes.enum.imported_from_inclusion_connect,
+                  LinkEnum.enum.imported_from_inclusion_connect,
               });
             }
           } catch (error) {

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -13,6 +13,7 @@ import {
   isSmallEtablissementPublic,
 } from "@proconnect-gouv/proconnect.identite/services/organization";
 import {
+  EmailDomainApprovedVerificationTypes,
   EmailDomainVerificationTypes,
   LinkTypes,
   ModerationTypeSchema,
@@ -382,43 +383,19 @@ export const joinOrganization = async ({
     }
   }
 
-  if (
-    some(organizationEmailDomains, {
-      domain,
-      verification_type: EmailDomainVerificationTypes.enum.verified,
-    })
-  ) {
-    return await linkUserToOrganization({
-      organization_id,
-      user_id,
-      verification_type: LinkTypes.enum.domain,
-    });
-  }
+  const approvedDomain = organizationEmailDomains.find(
+    ({ domain: organization_domain, verification_type }) =>
+      organization_domain === domain &&
+      EmailDomainApprovedVerificationTypes.safeParse(verification_type).success,
+  );
 
-  if (
-    some(organizationEmailDomains, {
-      domain,
-      verification_type: EmailDomainVerificationTypes.enum.external,
-    })
-  ) {
+  if (approvedDomain) {
     return await linkUserToOrganization({
       organization_id,
       user_id,
-      is_external: true,
-      verification_type: LinkTypes.enum.domain,
-    });
-  }
-
-  if (
-    some(organizationEmailDomains, {
-      domain,
-      verification_type:
-        EmailDomainVerificationTypes.enum.trackdechets_postal_mail,
-    })
-  ) {
-    return await linkUserToOrganization({
-      organization_id,
-      user_id,
+      is_external:
+        approvedDomain.verification_type ===
+        EmailDomainVerificationTypes.enum.external,
       verification_type: LinkTypes.enum.domain,
     });
   }

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -13,9 +13,8 @@ import {
   isSmallEtablissementPublic,
 } from "@proconnect-gouv/proconnect.identite/services/organization";
 import {
-  EmailDomainApprovedVerificationTypes,
-  EmailDomainVerificationTypes,
-  LinkTypes,
+  EmailDomainVerificationEnum,
+  LinkEnum,
   ModerationTypeSchema,
   type Organization,
   type User,
@@ -25,6 +24,7 @@ import * as Sentry from "@sentry/node";
 import { isEmpty, some } from "lodash-es";
 import { AssertionError } from "node:assert";
 import { inspect } from "node:util";
+import { EmailDomainApprovedVerificationEnum } from "../../../packages/identite/src/types";
 import {
   CRISP_WEBSITE_ID,
   FEATURE_BYPASS_MODERATION,
@@ -242,7 +242,7 @@ export const joinOrganization = async ({
   if (
     some(organizationEmailDomains, {
       domain,
-      verification_type: EmailDomainVerificationTypes.enum.refused,
+      verification_type: EmailDomainVerificationEnum.enum.refused,
     })
   ) {
     throw new DomainRefusedForOrganizationError(organization_id);
@@ -264,7 +264,7 @@ export const joinOrganization = async ({
       organization_id,
       user_id,
       verification_type:
-        LinkTypes.enum.no_verification_means_for_entreprise_unipersonnelle,
+        LinkEnum.enum.no_verification_means_for_entreprise_unipersonnelle,
     });
   }
 
@@ -273,7 +273,7 @@ export const joinOrganization = async ({
       organization_id,
       user_id,
       verification_type:
-        LinkTypes.enum.no_verification_means_for_small_association,
+        LinkEnum.enum.no_verification_means_for_small_association,
     });
   }
 
@@ -314,7 +314,7 @@ export const joinOrganization = async ({
       return await linkUserToOrganization({
         organization_id,
         user_id,
-        verification_type: LinkTypes.enum.code_sent_to_official_contact_email,
+        verification_type: LinkEnum.enum.code_sent_to_official_contact_email,
         needs_official_contact_email_verification: true,
       });
     }
@@ -327,7 +327,7 @@ export const joinOrganization = async ({
           organization_id,
           domain: contactDomain,
           domain_verification_type:
-            EmailDomainVerificationTypes.enum.official_contact,
+            EmailDomainVerificationEnum.enum.official_contact,
         });
       }
 
@@ -335,7 +335,7 @@ export const joinOrganization = async ({
         return await linkUserToOrganization({
           organization_id,
           user_id,
-          verification_type: LinkTypes.enum.official_contact_email,
+          verification_type: LinkEnum.enum.official_contact_email,
         });
       }
 
@@ -343,14 +343,14 @@ export const joinOrganization = async ({
         return await linkUserToOrganization({
           organization_id,
           user_id,
-          verification_type: LinkTypes.enum.domain,
+          verification_type: LinkEnum.enum.domain,
         });
       }
 
       return await linkUserToOrganization({
         organization_id,
         user_id,
-        verification_type: LinkTypes.enum.code_sent_to_official_contact_email,
+        verification_type: LinkEnum.enum.code_sent_to_official_contact_email,
         needs_official_contact_email_verification: true,
       });
     }
@@ -369,7 +369,7 @@ export const joinOrganization = async ({
       return await linkUserToOrganization({
         organization_id,
         user_id,
-        verification_type: LinkTypes.enum.official_contact_email,
+        verification_type: LinkEnum.enum.official_contact_email,
       });
     }
 
@@ -377,26 +377,26 @@ export const joinOrganization = async ({
       return await linkUserToOrganization({
         organization_id,
         user_id,
-        verification_type: LinkTypes.enum.code_sent_to_official_contact_email,
+        verification_type: LinkEnum.enum.code_sent_to_official_contact_email,
         needs_official_contact_email_verification: true,
       });
     }
   }
 
-  const approvedDomain = organizationEmailDomains.find(
+  const approvedEmailDomain = organizationEmailDomains.find(
     ({ domain: organization_domain, verification_type }) =>
       organization_domain === domain &&
-      EmailDomainApprovedVerificationTypes.safeParse(verification_type).success,
+      EmailDomainApprovedVerificationEnum.safeParse(verification_type).success,
   );
 
-  if (approvedDomain) {
+  if (approvedEmailDomain) {
     return await linkUserToOrganization({
       organization_id,
       user_id,
       is_external:
-        approvedDomain.verification_type ===
-        EmailDomainVerificationTypes.enum.external,
-      verification_type: LinkTypes.enum.domain,
+        approvedEmailDomain.verification_type ===
+        EmailDomainVerificationEnum.enum.external,
+      verification_type: LinkEnum.enum.domain,
     });
   }
 
@@ -404,14 +404,14 @@ export const joinOrganization = async ({
     return await linkUserToOrganization({
       organization_id,
       user_id,
-      verification_type: LinkTypes.enum.bypassed,
+      verification_type: LinkEnum.enum.bypassed,
     });
   }
 
   if (
     some(organizationEmailDomains, {
       domain,
-      verification_type: EmailDomainVerificationTypes.enum.not_verified_yet,
+      verification_type: EmailDomainVerificationEnum.enum.not_verified_yet,
     })
   ) {
     await createModeration({
@@ -424,7 +424,7 @@ export const joinOrganization = async ({
     return await linkUserToOrganization({
       organization_id,
       user_id,
-      verification_type: LinkTypes.enum.domain_not_verified_yet,
+      verification_type: LinkEnum.enum.domain_not_verified_yet,
     });
   }
 

--- a/src/managers/session/authenticated.ts
+++ b/src/managers/session/authenticated.ts
@@ -1,10 +1,10 @@
 import { NotFoundError } from "@proconnect-gouv/proconnect.identite/errors";
 import type { User } from "@proconnect-gouv/proconnect.identite/types";
 import {
-  StrongLinkTypes,
-  SuperWeakLinkTypes,
-  UnverifiedLinkTypes,
-  WeakLinkTypes,
+  StrongLinkValues,
+  SuperWeakLinkValues,
+  UnverifiedLinkValues,
+  WeakLinkValues,
 } from "@proconnect-gouv/proconnect.identite/types";
 import * as Sentry from "@sentry/node";
 import type { Request, Response } from "express";
@@ -270,9 +270,9 @@ export async function getCurrentIAL(req: Request) {
 
   return match(link.verification_type)
     .returnType<1 | 2 | 3>()
-    .with(...StrongLinkTypes, () => 3)
-    .with(...WeakLinkTypes, ...SuperWeakLinkTypes, () => 2)
-    .with(...UnverifiedLinkTypes, () => 1)
+    .with(...StrongLinkValues, () => 3)
+    .with(...WeakLinkValues, ...SuperWeakLinkValues, () => 2)
+    .with(...UnverifiedLinkValues, () => 1)
     .exhaustive();
 }
 

--- a/src/middlewares/navigation-guards.ts
+++ b/src/middlewares/navigation-guards.ts
@@ -1,12 +1,10 @@
 import { getTrustedReferrerPath } from "@proconnect-gouv/proconnect.core/security";
-import {
-  LinkTypes,
-  UnverifiedLinkTypes,
-} from "@proconnect-gouv/proconnect.identite/types";
+import { LinkEnum } from "@proconnect-gouv/proconnect.identite/types";
 import type { Request, RequestHandler } from "express";
 import HttpErrors from "http-errors";
 import { isEmpty } from "lodash-es";
 import { match, P } from "ts-pattern";
+import { UnverifiedLinkEnum } from "../../packages/identite/src/types";
 import {
   CERTIFICATION_DIRIGEANT_MAX_AGE_IN_MINUTES,
   HOST,
@@ -571,11 +569,9 @@ const userHasValidFranceConnectIdentityGuard = async <
     user_id,
   ))!;
 
-  const linkTypeIsUnverified = match(linkType)
-    .with(...UnverifiedLinkTypes, () => true)
-    .otherwise(() => false);
   const linkTypeRequiresFranceConnection =
-    linkTypeIsUnverified || linkType === LinkTypes.enum.organization_dirigeant;
+    UnverifiedLinkEnum.safeParse(linkType).success ||
+    linkType === LinkEnum.enum.organization_dirigeant;
 
   if (
     linkTypeRequiresFranceConnection &&
@@ -622,13 +618,13 @@ const userIsCertifiedAsDirigeantGuard = async <
 
   if (
     req.session.certificationDirigeantRequested &&
-    linkType !== LinkTypes.enum.organization_dirigeant
+    linkType !== LinkEnum.enum.organization_dirigeant
   ) {
     req.session.pendingCertificationDirigeantOrganizationId = organizationId;
     return processCertificationDirigeantGuard(context);
   }
 
-  if (linkType === LinkTypes.enum.organization_dirigeant) {
+  if (linkType === LinkEnum.enum.organization_dirigeant) {
     const franceconnectUserInfo = (await getFranceConnectUserInfo(user_id))!;
     const expiredCertification = isExpired(
       linkVerifiedAt,
@@ -728,7 +724,7 @@ const userHasBeenGreetedGuard = async (context: Pass<RequestContext>) => {
   if (!isEmpty(organizationThatNeedsGreetings)) {
     if (
       organizationThatNeedsGreetings.verification_type ===
-      LinkTypes.enum.organization_dirigeant
+      LinkEnum.enum.organization_dirigeant
     ) {
       await greetForCertification({
         user_id,
@@ -871,7 +867,7 @@ const processCertificationDirigeantGuard = async (
 
     if (await getUserOrganizationLink(organizationId, user_id)) {
       await updateUserOrganizationLink(organization.id, user_id, {
-        verification_type: LinkTypes.enum.organization_dirigeant,
+        verification_type: LinkEnum.enum.organization_dirigeant,
         verified_at: new Date(),
         has_been_greeted: false,
       });
@@ -879,7 +875,7 @@ const processCertificationDirigeantGuard = async (
       await linkUserToOrganization({
         user_id,
         organization_id: organization.id,
-        verification_type: LinkTypes.enum.organization_dirigeant,
+        verification_type: LinkEnum.enum.organization_dirigeant,
       });
     }
 

--- a/src/repositories/organization/getters.ts
+++ b/src/repositories/organization/getters.ts
@@ -1,5 +1,5 @@
 import {
-  EmailDomainApprovedVerificationTypes,
+  EmailDomainApprovedVerificationValues,
   ModerationTypeSchema,
   type Organization,
   type UserOrganizationLink,
@@ -62,7 +62,7 @@ export const findByVerifiedEmailDomain = async (email_domain: string) => {
         AND ed.verification_type = ANY ($2)
       GROUP BY o.id
       ORDER BY member_count DESC NULLS LAST;`,
-      [email_domain, EmailDomainApprovedVerificationTypes],
+      [email_domain, EmailDomainApprovedVerificationValues],
     );
 
   return rows;


### PR DESCRIPTION
    
  
**Problem**

New users whose email domain is tagged `official_contact` in the
`email_domains` table were not being auto-validated. The domain checks
in `joinOrganization` only handled `verified`, `external`, and
`trackdechets_postal_mail` types, so `official_contact` domains fell
through to moderation or threw `UnableToAutoJoinOrganizationError`.

**Proposal**

Extend the `verified` domain check to match all `EmailDomainApprovedVerificationValues`.