### PR TITLE
🐛 use new files in annuaire_entreprises script

### DIFF
--- a/packages/annuaire_entreprises/scripts/build-data.ts
+++ b/packages/annuaire_entreprises/scripts/build-data.ts
@@ -15,9 +15,8 @@ const commit = (await readFile(commitPath, "utf-8")).trim();
 console.log(`📦 Fetching data from search-infra@${commit.slice(0, 7)}`);
 
 const files = [
-  "administration_nature_juridique.json",
-  "administration_siren_blacklist.json",
-  "administration_siren_whitelist.json",
+  "administration_whitelist.json",
+  "administration_blacklist.json",
 ];
 
 const baseUrl = `https://raw.githubusercontent.com/annuaire-entreprises-data-gouv-fr/search-infra/${commit}/helpers/labels`;


### PR DESCRIPTION
**Problem**
Since the Annuaire des Entreprises update, our data duplication script has been failing because it still references outdated files.

**Proposal**
Update the script to point to the new files introduced by the Annuaire des Entreprises update.