### PR TITLE
🐛 Fix moderation `allow_editing` bypass

### DIFF
--- a/src/managers/moderation.ts
+++ b/src/managers/moderation.ts
@@ -60,7 +60,7 @@ export const reopenModerationWithUserEdit = async ({
 }) => {
   const moderation = await getModerationById(moderation_id);
 
-  if (user.id !== moderation.user_id) {
+  if (user.id !== moderation.user_id || !moderation.allow_editing) {
     throw new ForbiddenError();
   }
 


### PR DESCRIPTION
**Problem**

The moderation `allow_editing` flag controls whether the form used to reopen a moderation after it has been processed is displayed.

The `/users/reopen-moderation/:id` endpoint does not check this flag, allowing users to bypass the editing lock and reopen a closed moderation.

**Proposal**

Check the `allow_editing` flag in the `reopenModerationWithUserEdit` manager to prevent this bypass.