### PR TITLE
🐛 fix impossibility to run the update-grist script

### DIFF
--- a/.github/workflows/update-grist.yml
+++ b/.github/workflows/update-grist.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - "packages/annuaire_entreprises/scripts/update-grist.ts"
       - ".github/workflows/update-grist.yml"
+  workflow_dispatch:
+
 jobs:
   update:
     name: 🔄 Update data files


### PR DESCRIPTION
**Problem**
The `update-grist` script cannot be triggered manually.

**Proposal**
Add the `workflow_dispatch` event to the GitHub Action to allow manual execution.