### PR TITLE
🐛 fix(types): use import type for pg in contexts.ts

### DIFF
--- a/packages/identite/src/types/contexts.ts
+++ b/packages/identite/src/types/contexts.ts
@@ -1,6 +1,6 @@
 //
 
-import Pg from "pg";
+import type Pg from "pg";
 
 //
 


### PR DESCRIPTION
<div align=center><img src="https://media2.giphy.com/media/v1.Y2lkPWVjMTJjNzA0NHhxZjdhcjBsZHUzYmw2aXJraGpreWlnN3c1cDNtbGg4cHdyYnl2eiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/z23hGvopHu7w4/giphy.gif" /></div>

---

## Problem

`contexts.ts` uses `import Pg from "pg"` but `Pg` is only referenced in a type position (`Pg.Pool`). This compiles to a **value import** in the dist, which causes the entire `@proconnect-gouv/proconnect.identite/types` barrel to pull `pg` into any bundler targeting the browser.

Consumers who import anything from the types barrel (e.g. `LinkTypes`, `ModerationTypeSchema`) hit a hard build error:

```
error: Browser build cannot require() Node.js builtin: "tls"
    at pg/lib/stream.js
error: Browser build cannot require() Node.js builtin: "dns"
    at pg/lib/connection-parameters.js
```

## Proposal

Change `import Pg from "pg"` to `import type Pg from "pg"`. Type-only imports are fully erased at compile time — zero runtime footprint, no bundler side-effects.