### PR TITLE
🔍 debug: add workflow to check NPM_TOKEN identity

### DIFF
--- a/.github/workflows/debug-npm-token.yml
+++ b/.github/workflows/debug-npm-token.yml
@@ -1,0 +1,19 @@
+name: 🔍 Debug NPM Token
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check npm identity
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Check access to @proconnect-gouv scope
+        run: npm access list packages @proconnect-gouv --registry https://registry.npmjs.org
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        continue-on-error: true


### PR DESCRIPTION
Temporary debug workflow to diagnose the E404 on npm publish. Runs `npm whoami` and `npm access list packages` with `NPM_TOKEN` — outputs the account identity without exposing the secret.