### PR TITLE
📧 Make alternative sender ratio more granular

### DIFF
--- a/cypress/e2e/signin_with_magic_link/index.cy.ts
+++ b/cypress/e2e/signin_with_magic_link/index.cy.ts
@@ -121,11 +121,11 @@ describe("sign-in with magic link", () => {
     );
   });
 
-  it("should use alt sender email when email length is a multiple of 4", function () {
+  it("should use alt sender email when email length is a multiple of 10", function () {
     cy.visit("/users/start-sign-in");
 
     cy.contains("Email professionnel").click();
-    cy.focused().type("user@example.com");
+    cy.focused().type("user1234@example.com");
     cy.contains("Continuer").click();
 
     cy.contains("Recevoir un lien de connexion").click();

--- a/src/config/env.zod.ts
+++ b/src/config/env.zod.ts
@@ -189,7 +189,7 @@ export const paramsEnvSchema = z.object({
     .int()
     .nonnegative()
     .default(3 * 30 * 24 * 60 * 60), // 3 months in seconds
-  SMTP_FROM_ALT_RATIO_PERCENT: z.coerce.number().min(0).max(100).default(25),
+  SMTP_FROM_ALT_RATIO_PERCENT: z.coerce.number().min(0).max(100).default(10),
   USE_SMTP_FROM_ALT_FOR_DOMAINS: zCoerceArray().default([]),
   VERIFY_EMAIL_TOKEN_EXPIRATION_DURATION_IN_MINUTES: z.coerce
     .number()

--- a/src/connectors/mail.ts
+++ b/src/connectors/mail.ts
@@ -39,9 +39,8 @@ export function sendMail(options: SendMailBrevoOptions) {
       // We use length + modulo for reproducibility when we want to debug users.
       // We also use length + modulo for testability, so the same test case always returns the same result.
       // We use the length of the email for simplicity: the length is easy to compute and can be calculated by hand.
-      // We use modulo 4 to mitigate uneven distribution: the distribution might be more uneven with a higher modulus.
       // We use a percentage for the sake of readability: it is easier to manipulate a percentage than a modulo from an external perspective.
-      toEmail.length % 4 < (SMTP_FROM_ALT_RATIO_PERCENT / 100) * 4;
+      toEmail.length % 10 < (SMTP_FROM_ALT_RATIO_PERCENT / 100) * 10;
   }
 
   return transporter.sendMail({

--- a/test/env.zod.test.ts
+++ b/test/env.zod.test.ts
@@ -114,7 +114,7 @@ describe("env.zod", () => {
       SESSION_MAX_AGE_IN_SECONDS: 86400,
       SMTP_FROM: "nepasrepondre@email.moncomptepro.beta.gouv.fr",
       SMTP_FROM_ALT: "nepasrepondre@email.proconnect.gouv.fr",
-      SMTP_FROM_ALT_RATIO_PERCENT: 25,
+      SMTP_FROM_ALT_RATIO_PERCENT: 10,
       SMTP_URL: "smtp://localhost:1025",
       SYMMETRIC_ENCRYPTION_KEY: "aTrueRandom32BytesLongBase64EncodedStringAA=",
       TEST_CONTACT_EMAIL: "mairie@yopmail.com",


### PR DESCRIPTION
**Problem**

When sending 25% of our emails with the alternative sender address, we are flagged as spam by `https://ipcheck.proofpoint.com/`.

**Proposal**

Implement a more granular percentage to smooth the sending ratio with the alternative sender address, as an attempt to avoid triggering antispam software.