### PR TITLE
🚀 make rne package public

### DIFF
--- a/.changeset/ninety-files-itch.md
+++ b/.changeset/ninety-files-itch.md
@@ -1,0 +1,5 @@
+---
+"@proconnect-gouv/proconnect.registre_national_entreprises": major
+---
+
+publication du package registre_national_entreprises

--- a/packages/registre_national_entreprises/package.json
+++ b/packages/registre_national_entreprises/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@proconnect-gouv/proconnect.registre_national_entreprises",
   "version": "3.0.0",
-  "private": true,
   "homepage": "https://github.com/proconnect-gouv/proconnect-identite/tree/main/packages/registre_national_entreprises#readme",
   "bugs": "https://github.com/proconnect-gouv/proconnect-identite/issues",
   "repository": {


### PR DESCRIPTION
**Problem**
The ProConnect Identité package now depends on the `registre_national_entreprises` package, which is not publicly available.

**Proposal**
Publish the `registre_national_entreprises` package so it can be consumed as a dependency by ProConnect Identité.