### PR TITLE
👔 join: skip moderation for small organizations with free email

### DIFF
--- a/cypress/e2e/join_with_free_email_domain/index.cy.ts
+++ b/cypress/e2e/join_with_free_email_domain/index.cy.ts
@@ -244,3 +244,48 @@ describe("join small association", () => {
     });
   });
 });
+
+describe("join small organization", () => {
+  before(cy.seed);
+
+  const organizations = [
+    {
+      siret: "41782415800014",
+      categorie_juridique: "Exploitation agricole à responsabilité limitée",
+    },
+    {
+      siret: "80894789900015",
+      categorie_juridique:
+        "Groupement agricole d'exploitation en commun (GAEC)",
+    },
+    {
+      siret: "33156427800017",
+      categorie_juridique: "Groupement foncier agricole",
+    },
+    {
+      siret: "83932047000017",
+      categorie_juridique: "Société civile d'exploitation agricole",
+    },
+    {
+      siret: "79271377800019",
+      categorie_juridique: "Société civile immobilière",
+    },
+  ];
+
+  beforeEach(() => {
+    cy.visit("/");
+    cy.login("lion.eljonson@yopmail.com");
+    cy.visit("/users/join-organization");
+
+    cy.title().should("include", "Rejoindre une organisation -");
+    cy.contains("SIRET de l’organisation que vous représentez").click();
+  });
+
+  organizations.forEach(({ siret, categorie_juridique }) => {
+    it(categorie_juridique, function () {
+      cy.focused().clear().type(siret);
+      cy.contains("Enregistrer").click();
+      cy.contains("Compte créé");
+    });
+  });
+});

--- a/packages/identite/src/types/user-organization-link.ts
+++ b/packages/identite/src/types/user-organization-link.ts
@@ -37,6 +37,7 @@ export const UnverifiedLinkValues = [
   "no_validation_means_available",
   "no_verification_means_for_entreprise_unipersonnelle",
   "no_verification_means_for_small_association",
+  "no_verification_means_for_small_organization",
 ] as const;
 
 export const UnverifiedLinkEnum = z.enum(UnverifiedLinkValues);

--- a/packages/testing/src/api/routes/entreprise.api.gouv.fr/etablissements/33156427800017.json
+++ b/packages/testing/src/api/routes/entreprise.api.gouv.fr/etablissements/33156427800017.json
@@ -1,0 +1,100 @@
+{
+  "data": {
+    "siret": "33156427800017",
+    "siege_social": true,
+    "etat_administratif": "A",
+    "date_fermeture": null,
+    "enseigne": null,
+    "activite_principale": {
+      "code": "02.10Z",
+      "nomenclature": "NAFRev2",
+      "libelle": "Sylviculture et autres activités forestières"
+    },
+    "tranche_effectif_salarie": {
+      "de": null,
+      "a": null,
+      "code": "NN",
+      "date_reference": null,
+      "intitule": "Unités non employeuses"
+    },
+    "diffusable_commercialement": true,
+    "status_diffusion": "diffusible",
+    "date_creation": 483660000,
+    "unite_legale": {
+      "siren": "331564278",
+      "rna": null,
+      "siret_siege_social": "33156427800017",
+      "type": "personne_morale",
+      "personne_morale_attributs": {
+        "raison_sociale": "GFA DE FAY DENIECOURT",
+        "sigle": null
+      },
+      "personne_physique_attributs": {
+        "pseudonyme": null,
+        "prenom_usuel": null,
+        "prenom_1": null,
+        "prenom_2": null,
+        "prenom_3": null,
+        "prenom_4": null,
+        "nom_usage": null,
+        "nom_naissance": null,
+        "sexe": null
+      },
+      "categorie_entreprise": null,
+      "status_diffusion": "diffusible",
+      "diffusable_commercialement": true,
+      "forme_juridique": {
+        "code": "6534",
+        "libelle": "Groupement foncier agricole"
+      },
+      "activite_principale": {
+        "code": "02.10Z",
+        "nomenclature": "NAFRev2",
+        "libelle": "Sylviculture et autres activités forestières"
+      },
+      "tranche_effectif_salarie": {
+        "de": null,
+        "a": null,
+        "code": "NN",
+        "date_reference": null,
+        "intitule": "Unités non employeuses"
+      },
+      "economie_sociale_et_solidaire": null,
+      "date_creation": 483660000,
+      "etat_administratif": "A"
+    },
+    "adresse": {
+      "status_diffusion": "diffusible",
+      "complement_adresse": null,
+      "numero_voie": null,
+      "indice_repetition_voie": null,
+      "type_voie": null,
+      "libelle_voie": "LE CHATEAU",
+      "code_postal": "38780",
+      "libelle_commune": "SEPTEME",
+      "libelle_commune_etranger": null,
+      "distribution_speciale": null,
+      "code_commune": "38480",
+      "code_cedex": null,
+      "libelle_cedex": null,
+      "code_pays_etranger": null,
+      "libelle_pays_etranger": null,
+      "acheminement_postal": {
+        "l1": "GFA DE FAY DENIECOURT",
+        "l2": "",
+        "l3": "",
+        "l4": "LE CHATEAU",
+        "l5": "",
+        "l6": "38780 SEPTEME",
+        "l7": "FRANCE"
+      }
+    }
+  },
+  "links": {
+    "unite_legale": "https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/331564278"
+  },
+  "meta": {
+    "date_derniere_mise_a_jour": 1764889200,
+    "redirect_from_siret": null
+  }
+}

--- a/packages/testing/src/api/routes/entreprise.api.gouv.fr/etablissements/41782415800014.json
+++ b/packages/testing/src/api/routes/entreprise.api.gouv.fr/etablissements/41782415800014.json
@@ -1,0 +1,100 @@
+{
+  "data": {
+    "siret": "41782415800014",
+    "siege_social": true,
+    "etat_administratif": "A",
+    "date_fermeture": null,
+    "enseigne": null,
+    "activite_principale": {
+      "code": "01.11Z",
+      "nomenclature": "NAFRev2",
+      "libelle": "Culture de céréales (à l'exception du riz), de légumineuses et de graines oléagineuses"
+    },
+    "tranche_effectif_salarie": {
+      "de": 1,
+      "a": 2,
+      "code": "01",
+      "date_reference": "2023",
+      "intitule": "1 ou 2 salariés"
+    },
+    "diffusable_commercialement": true,
+    "status_diffusion": "diffusible",
+    "date_creation": 887497200,
+    "unite_legale": {
+      "siren": "417824158",
+      "rna": null,
+      "siret_siege_social": "41782415800014",
+      "type": "personne_morale",
+      "personne_morale_attributs": {
+        "raison_sociale": "EARL BRUNO GOUOT",
+        "sigle": null
+      },
+      "personne_physique_attributs": {
+        "pseudonyme": null,
+        "prenom_usuel": null,
+        "prenom_1": null,
+        "prenom_2": null,
+        "prenom_3": null,
+        "prenom_4": null,
+        "nom_usage": null,
+        "nom_naissance": null,
+        "sexe": null
+      },
+      "categorie_entreprise": null,
+      "status_diffusion": "diffusible",
+      "diffusable_commercialement": true,
+      "forme_juridique": {
+        "code": "6598",
+        "libelle": "Exploitation agricole à responsabilité limitée"
+      },
+      "activite_principale": {
+        "code": "01.11Z",
+        "nomenclature": "NAFRev2",
+        "libelle": "Culture de céréales (à l'exception du riz), de légumineuses et de graines oléagineuses"
+      },
+      "tranche_effectif_salarie": {
+        "de": 1,
+        "a": 2,
+        "code": "01",
+        "date_reference": "2023",
+        "intitule": "1 ou 2 salariés"
+      },
+      "economie_sociale_et_solidaire": null,
+      "date_creation": 887497200,
+      "etat_administratif": "A"
+    },
+    "adresse": {
+      "status_diffusion": "diffusible",
+      "complement_adresse": null,
+      "numero_voie": null,
+      "indice_repetition_voie": null,
+      "type_voie": null,
+      "libelle_voie": "LA TUILERIE",
+      "code_postal": "89160",
+      "libelle_commune": "JULLY",
+      "libelle_commune_etranger": null,
+      "distribution_speciale": null,
+      "code_commune": "89210",
+      "code_cedex": null,
+      "libelle_cedex": null,
+      "code_pays_etranger": null,
+      "libelle_pays_etranger": null,
+      "acheminement_postal": {
+        "l1": "EARL BRUNO GOUOT",
+        "l2": "",
+        "l3": "",
+        "l4": "LA TUILERIE",
+        "l5": "",
+        "l6": "89160 JULLY",
+        "l7": "FRANCE"
+      }
+    }
+  },
+  "links": {
+    "unite_legale": "https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/417824158"
+  },
+  "meta": {
+    "date_derniere_mise_a_jour": 1764889200,
+    "redirect_from_siret": null
+  }
+}

--- a/packages/testing/src/api/routes/entreprise.api.gouv.fr/etablissements/80894789900015.json
+++ b/packages/testing/src/api/routes/entreprise.api.gouv.fr/etablissements/80894789900015.json
@@ -1,0 +1,100 @@
+{
+  "data": {
+    "siret": "80894789900015",
+    "siege_social": true,
+    "etat_administratif": "A",
+    "date_fermeture": null,
+    "enseigne": null,
+    "activite_principale": {
+      "code": "01.21Z",
+      "nomenclature": "NAFRev2",
+      "libelle": "Culture de la vigne"
+    },
+    "tranche_effectif_salarie": {
+      "de": null,
+      "a": null,
+      "code": "NN",
+      "date_reference": null,
+      "intitule": "Unités non employeuses"
+    },
+    "diffusable_commercialement": true,
+    "status_diffusion": "diffusible",
+    "date_creation": 1420153200,
+    "unite_legale": {
+      "siren": "808947899",
+      "rna": null,
+      "siret_siege_social": "80894789900015",
+      "type": "personne_morale",
+      "personne_morale_attributs": {
+        "raison_sociale": "GAEC LA GRANGE NEUVE",
+        "sigle": null
+      },
+      "personne_physique_attributs": {
+        "pseudonyme": null,
+        "prenom_usuel": null,
+        "prenom_1": null,
+        "prenom_2": null,
+        "prenom_3": null,
+        "prenom_4": null,
+        "nom_usage": null,
+        "nom_naissance": null,
+        "sexe": null
+      },
+      "categorie_entreprise": null,
+      "status_diffusion": "diffusible",
+      "diffusable_commercialement": true,
+      "forme_juridique": {
+        "code": "6533",
+        "libelle": "Groupement agricole d'exploitation en commun (GAEC)"
+      },
+      "activite_principale": {
+        "code": "01.21Z",
+        "nomenclature": "NAFRev2",
+        "libelle": "Culture de la vigne"
+      },
+      "tranche_effectif_salarie": {
+        "de": null,
+        "a": null,
+        "code": "NN",
+        "date_reference": null,
+        "intitule": "Unités non employeuses"
+      },
+      "economie_sociale_et_solidaire": false,
+      "date_creation": 1420153200,
+      "etat_administratif": "A"
+    },
+    "adresse": {
+      "status_diffusion": "diffusible",
+      "complement_adresse": null,
+      "numero_voie": null,
+      "indice_repetition_voie": null,
+      "type_voie": null,
+      "libelle_voie": "LA GRANGE NEUVE",
+      "code_postal": "84190",
+      "libelle_commune": "SUZETTE",
+      "libelle_commune_etranger": null,
+      "distribution_speciale": null,
+      "code_commune": "84130",
+      "code_cedex": null,
+      "libelle_cedex": null,
+      "code_pays_etranger": null,
+      "libelle_pays_etranger": null,
+      "acheminement_postal": {
+        "l1": "GAEC LA GRANGE NEUVE",
+        "l2": "",
+        "l3": "",
+        "l4": "LA GRANGE NEUVE",
+        "l5": "",
+        "l6": "84190 SUZETTE",
+        "l7": "FRANCE"
+      }
+    }
+  },
+  "links": {
+    "unite_legale": "https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/808947899"
+  },
+  "meta": {
+    "date_derniere_mise_a_jour": 1764889200,
+    "redirect_from_siret": null
+  }
+}

--- a/packages/testing/src/api/routes/entreprise.api.gouv.fr/etablissements/83932047000017.json
+++ b/packages/testing/src/api/routes/entreprise.api.gouv.fr/etablissements/83932047000017.json
@@ -1,0 +1,100 @@
+{
+  "data": {
+    "siret": "83932047000017",
+    "siege_social": true,
+    "etat_administratif": "A",
+    "date_fermeture": null,
+    "enseigne": null,
+    "activite_principale": {
+      "code": "01.45Z",
+      "nomenclature": "NAFRev2",
+      "libelle": "Élevage d'ovins et de caprins"
+    },
+    "tranche_effectif_salarie": {
+      "de": 1,
+      "a": 2,
+      "code": "01",
+      "date_reference": "2023",
+      "intitule": "1 ou 2 salariés"
+    },
+    "diffusable_commercialement": true,
+    "status_diffusion": "diffusible",
+    "date_creation": 1519858800,
+    "unite_legale": {
+      "siren": "839320470",
+      "rna": null,
+      "siret_siege_social": "83932047000017",
+      "type": "personne_morale",
+      "personne_morale_attributs": {
+        "raison_sociale": "SOCIETE CIVILE D EXPLOITATION AGRICOLE BOURDON",
+        "sigle": "SCEA"
+      },
+      "personne_physique_attributs": {
+        "pseudonyme": null,
+        "prenom_usuel": null,
+        "prenom_1": null,
+        "prenom_2": null,
+        "prenom_3": null,
+        "prenom_4": null,
+        "nom_usage": null,
+        "nom_naissance": null,
+        "sexe": null
+      },
+      "categorie_entreprise": null,
+      "status_diffusion": "diffusible",
+      "diffusable_commercialement": true,
+      "forme_juridique": {
+        "code": "6597",
+        "libelle": "Société civile d'exploitation agricole"
+      },
+      "activite_principale": {
+        "code": "01.45Z",
+        "nomenclature": "NAFRev2",
+        "libelle": "Élevage d'ovins et de caprins"
+      },
+      "tranche_effectif_salarie": {
+        "de": 1,
+        "a": 2,
+        "code": "01",
+        "date_reference": "2023",
+        "intitule": "1 ou 2 salariés"
+      },
+      "economie_sociale_et_solidaire": null,
+      "date_creation": 1519858800,
+      "etat_administratif": "A"
+    },
+    "adresse": {
+      "status_diffusion": "diffusible",
+      "complement_adresse": null,
+      "numero_voie": null,
+      "indice_repetition_voie": null,
+      "type_voie": null,
+      "libelle_voie": "VILLENEUVE",
+      "code_postal": "53220",
+      "libelle_commune": "PONTMAIN",
+      "libelle_commune_etranger": null,
+      "distribution_speciale": null,
+      "code_commune": "53181",
+      "code_cedex": null,
+      "libelle_cedex": null,
+      "code_pays_etranger": null,
+      "libelle_pays_etranger": null,
+      "acheminement_postal": {
+        "l1": "SOCIETE CIVILE D EXPLOITATION AGRICOLE BOURDON",
+        "l2": "",
+        "l3": "",
+        "l4": "VILLENEUVE",
+        "l5": "",
+        "l6": "53220 PONTMAIN",
+        "l7": "FRANCE"
+      }
+    }
+  },
+  "links": {
+    "unite_legale": "https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/839320470"
+  },
+  "meta": {
+    "date_derniere_mise_a_jour": 1764889200,
+    "redirect_from_siret": null
+  }
+}

--- a/packages/testing/src/cli/entreprise/index.ts
+++ b/packages/testing/src/cli/entreprise/index.ts
@@ -28,7 +28,7 @@ export function EntrepriseCommandFactory({
           },
           rootDir: {
             type: "string",
-            default: join(import.meta.dirname, "../.."),
+            default: join(import.meta.dirname, "../../../src"),
           },
           url: { type: "string", default: ENTREPRISE_API_URL },
         })

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -78,6 +78,7 @@ import {
   isEducationNationaleDomain,
   isEtablissementScolaireDuPremierEtSecondDegre,
   isSmallAssociation,
+  isSmallOrganization,
 } from "../../services/organization";
 import { unableToAutoJoinOrganizationMd } from "../../views/mails/unable-to-auto-join-organization";
 import { getOrganizationsByUserId, markDomainAsVerified } from "./main";
@@ -274,6 +275,15 @@ export const joinOrganization = async ({
       user_id,
       verification_type:
         LinkEnum.enum.no_verification_means_for_small_association,
+    });
+  }
+
+  if (isSmallOrganization(organization) && isAFreeEmailProvider(email)) {
+    return await linkUserToOrganization({
+      organization_id,
+      user_id,
+      verification_type:
+        LinkEnum.enum.no_verification_means_for_small_organization,
     });
   }
 

--- a/src/services/organization.ts
+++ b/src/services/organization.ts
@@ -5,6 +5,25 @@ import {
 } from "@proconnect-gouv/proconnect.identite/services/organization";
 import type { Organization } from "@proconnect-gouv/proconnect.identite/types";
 
+export const isSmallOrganization = ({
+  cached_libelle_categorie_juridique,
+  cached_tranche_effectifs_unite_legale,
+}: Organization): boolean => {
+  const cat_jur_ok = [
+    "Exploitation agricole à responsabilité limitée",
+    "Groupement agricole d'exploitation en commun (GAEC)",
+    "Groupement foncier agricole",
+    "Société civile d'exploitation agricole",
+    "Société civile immobilière",
+  ].includes(cached_libelle_categorie_juridique || "");
+
+  const tra_eff_ok = [null, "NN", "00", "01"].includes(
+    cached_tranche_effectifs_unite_legale,
+  );
+
+  return cat_jur_ok && tra_eff_ok;
+};
+
 export const isSmallAssociation = ({
   cached_libelle_categorie_juridique,
   cached_tranche_effectifs_unite_legale,


### PR DESCRIPTION
**Problem**

Small civil and agricultural structures (EARL, SCEA, GAEC, SCI, GFA) with ≤2 employees and a free email domain are hard to moderate — no official contact email, no verifiable domain — causing unnecessary moderation noise for entities that mirror the small association case.

**Proposal**

Introduce `isSmallOrganization` to identify these 5 legal types at tranche effectifs NN/00/01, and add a dedicated
`no_verification_means_for_small_organization` link value so they join the same way small associations do.