### PR TITLE
🐛 certification: drop org selection after a failed certification

### DIFF
--- a/cypress/e2e/join_and_moderation/index.cy.ts
+++ b/cypress/e2e/join_and_moderation/index.cy.ts
@@ -132,4 +132,31 @@ describe("join and moderation", () => {
       cy.contains("Demande en cours");
     });
   });
+
+  describe("denied access", () => {
+    it("does not auto-select the organization after a denied access", function () {
+      cy.origin("http://localhost:4000", () => {
+        cy.visit("/");
+        cy.title().should("include", "standard-client - ProConnect");
+        cy.contains("S’identifier avec ProConnect").click();
+      });
+
+      cy.magicLinkLogin("denied-access+rogal.dorn@vip.gouv.fr");
+
+      cy.title().should("include", "Rejoindre une organisation -");
+      cy.contains("SIRET de l’organisation que vous représentez").click();
+      cy.focused().clear().type("31723624800017");
+      cy.contains("Enregistrer").click();
+
+      cy.title().should("include", "Email non autorisé -");
+      cy.contains("Email non autorisé");
+
+      cy.origin("http://localhost:4000", () => {
+        cy.visit("/");
+        cy.contains("S’identifier avec ProConnect").click();
+      });
+
+      cy.title().should("include", "Rejoindre une organisation -");
+    });
+  });
 });

--- a/cypress/e2e/signin_with_certification_dirigeant/index.cy.ts
+++ b/cypress/e2e/signin_with_certification_dirigeant/index.cy.ts
@@ -236,6 +236,26 @@ describe("sign-in with a client requiring certification dirigeant", () => {
     cy.contains("login_required");
     cy.contains("Certification dirigeant: no match error");
   });
+
+  it("should not auto-select the organization after a failed certification", function () {
+    cy.login("outdated-certification+ex-dirigeant@unipersonnelle.com");
+
+    cy.title().should("include", "Choisir une organisation -");
+    cy.getByLabel("Clamart (choisir cette organisation)").click();
+
+    cy.title().should("include", "Certification impossible -");
+    cy.contains("Identité non trouvée ⚠️");
+
+    // Re-initiate the authorization request without re-logging in.
+    cy.origin("http://localhost:4000", function () {
+      cy.visit("/");
+      cy.contains("Forcer une connexion par certification dirigeant").click();
+    });
+
+    // The previously-selected organization must NOT be auto-selected:
+    // the user is asked to choose its organization again.
+    cy.title().should("include", "Choisir une organisation -");
+  });
 });
 
 describe("connected user should go through the certification flow", function () {

--- a/src/middlewares/navigation-guards.ts
+++ b/src/middlewares/navigation-guards.ts
@@ -54,7 +54,10 @@ import {
   linkUserToOrganization,
   updateUserOrganizationLink,
 } from "../repositories/organization/setters";
-import { getSelectedOrganizationId } from "../repositories/redis/selected-organization";
+import {
+  deleteSelectedOrganizationId,
+  getSelectedOrganizationId,
+} from "../repositories/redis/selected-organization";
 import { getFranceConnectUserInfo } from "../repositories/user";
 import { isExpired } from "../services/is-expired";
 import { logger } from "../services/log";
@@ -890,6 +893,9 @@ const processCertificationDirigeantGuard = async (
 
     return connectToSp(prev);
   } catch (error) {
+    req.session.pendingCertificationDirigeantOrganizationId = undefined;
+    await deleteSelectedOrganizationId(user_id);
+
     if (error instanceof CertificationDirigeantOrganizationNotCoveredError) {
       return redirect(
         "/users/certification-dirigeant/organization-not-covered-error",


### PR DESCRIPTION
**Problem**

After a certification dirigeant hard-failure (no-match / close-match / not-covered), the chosen organization stayed selected in Redis and `pendingCertificationDirigeantOrganizationId` stayed set in the session. On the next authorization the user was either resumed straight back into the failing certification (via `userSignInRequirementsGuard`) or silently auto-selected into that organization, never getting the chance to pick another one.

**Proposal**

Clear both the pending-certification session id and the Redis selection in the certification guard's catch block, so a failed certification sends the user back to organization selection. Cover it with an e2e test, and add a join/moderation e2e test proving the non-certification denied-access paths never auto-select an organization either.