### PR TITLE
fix: restore testing SIRET generation script

### DIFF
--- a/packages/testing/src/cli/entreprise/index.ts
+++ b/packages/testing/src/cli/entreprise/index.ts
@@ -28,7 +28,7 @@ export function EntrepriseCommandFactory({
           },
           rootDir: {
             type: "string",
-            default: join(import.meta.dirname, "../.."),
+            default: join(import.meta.dirname, "../../../src"),
           },
           url: { type: "string", default: ENTREPRISE_API_URL },
         })


### PR DESCRIPTION
**Problem**
The script used to add new testing SIRETs no longer works since the export system was changed.

**Proposal**
Specify the exact location of the `src` directory so the script can correctly resolve imports and generate testing SIRETs.