### PR TITLE
🗃️ moderation: set allow_editing default to false

### DIFF
--- a/.changeset/slick-nails-tap.md
+++ b/.changeset/slick-nails-tap.md
@@ -1,0 +1,5 @@
+---
+"@proconnect-gouv/proconnect.identite.database": minor
+---
+
+🗃️ le champ allow_editing sur la table modérations est falsy par défaut

--- a/migrations/1780924063334_allow-editing-default-to-false-in-moderation.ts
+++ b/migrations/1780924063334_allow-editing-default-to-false-in-moderation.ts
@@ -1,0 +1,15 @@
+import { type ColumnDefinitions, MigrationBuilder } from "node-pg-migrate";
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  await pgm.db.query(`
+    ALTER TABLE moderations ALTER COLUMN allow_editing SET DEFAULT FALSE
+  `);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  await pgm.db.query(`
+    ALTER TABLE moderations ALTER COLUMN allow_editing DROP DEFAULT
+  `);
+}

--- a/packages/database/schema.sql
+++ b/packages/database/schema.sql
@@ -257,7 +257,7 @@ CREATE TABLE "public"."moderations" (
   "ticket_id" "text",
   "status" "text" DEFAULT 'unknown'::"text" NOT NULL,
   "sp_name" character varying,
-  "allow_editing" boolean NOT NULL,
+  "allow_editing" boolean DEFAULT false NOT NULL,
   "end_user_reason" character varying(255) DEFAULT 'Raison transmise par mail'::character varying NOT NULL
 );
 

--- a/packages/database/src/drizzle/schema.ts
+++ b/packages/database/src/drizzle/schema.ts
@@ -276,7 +276,7 @@ export const moderations = pgTable(
     ticket_id: text(),
     status: text().default("unknown").notNull(),
     sp_name: varchar(),
-    allow_editing: boolean().notNull(),
+    allow_editing: boolean().default(false).notNull(),
     end_user_reason: varchar({ length: 255 })
       .default("Raison transmise par mail")
       .notNull(),


### PR DESCRIPTION
**Problem**

The `allow_editing` column on `moderations` had no default value, requiring every insert to explicitly provide it.

**Proposal**

Set the column default to `FALSE` so new moderation records are non-editable by default, reducing the risk of accidental omission.