### PR TITLE
 🗃️ database: update schema dump for PostgreSQL 17 compatibility

### DIFF
--- a/packages/database/schema.sql
+++ b/packages/database/schema.sql
@@ -1,8 +1,8 @@
 --
 -- PostgreSQL database dump
 --
--- Dumped from database version 16.9 (Debian 16.9-1.pgdg130+1)
--- Dumped by pg_dump version 16.9 (Debian 16.9-1.pgdg130+1)
+-- Dumped from database version 17.9 (Debian 17.9-1.pgdg13+1)
+-- Dumped by pg_dump version 17.9 (Debian 17.9-1.pgdg13+1)
 SET
   statement_timeout = 0;
 
@@ -11,6 +11,9 @@ SET
 
 SET
   idle_in_transaction_session_timeout = 0;
+
+SET
+  transaction_timeout = 0;
 
 SET
   client_encoding = 'UTF8';

--- a/packages/database/scripts/build.ts
+++ b/packages/database/scripts/build.ts
@@ -32,6 +32,16 @@ await $`docker compose exec -T db pg_dump ${[
   "--schema-only",
   "--username=proconnect-identite",
 ]} > schema.sql`;
+
+{
+  let file_content = await readFile(
+    resolve(database_workspace, "schema.sql"),
+    "utf8",
+  );
+  file_content = file_content.replace(/^\\(un)?restrict\s.*\n/gm, "");
+  await writeFile(resolve(database_workspace, "schema.sql"), file_content);
+}
+
 await $({ cwd: database_workspace })`prettier --write schema.sql`;
 
 await $`drizzle-kit pull`;


### PR DESCRIPTION
**Problem**

pg_dump from PostgreSQL 17 emits `\restrict` / `\unrestrict` lines that break downstream tooling (drizzle-kit pull, prettier) and clutter the schema diff.

**Proposal**

Strip those lines in the build script post-dump step and regenerate the schema.sql against the updated PostgreSQL 17 dump format.