### PR TITLE
🏷️ certification-dirigeant: narrow parameter type to Pick

### DIFF
--- a/.changeset/smart-snakes-report.md
+++ b/.changeset/smart-snakes-report.md
@@ -1,0 +1,5 @@
+---
+"@proconnect-gouv/proconnect.identite": patch
+---
+
+🔧 Simplification du type du paramètre de `isOrganizationCoveredByCertificationDirigeant` : `Organization` → `Pick<Organization, "cached_categorie_juridique">`

--- a/packages/identite/src/services/organization/is-organization-covered-by-certification-dirigeant.ts
+++ b/packages/identite/src/services/organization/is-organization-covered-by-certification-dirigeant.ts
@@ -3,7 +3,7 @@ import type { Organization } from "#src/types";
 
 export const isOrganizationCoveredByCertificationDirigeant = ({
   cached_categorie_juridique,
-}: Organization) =>
+}: Pick<Organization, "cached_categorie_juridique">) =>
   CATEGORIES_JURIDIQUES.map(
     ({ categorie_juridique }) => categorie_juridique,
   ).includes(cached_categorie_juridique || "");


### PR DESCRIPTION
**Problem**

`isOrganizationCoveredByCertificationDirigeant` accepted a full `Organization`
but only ever read `cached_categorie_juridique`, making the contract broader
than necessary.

**Proposal**

Restrict the parameter to `Pick<Organization, "cached_categorie_juridique">`.
All existing callers pass full `Organization` objects, so they remain compatible.