### PR TITLE
⚡ perf: index users_oidc_clients on (user_id, created_at DESC)

### DIFF
--- a/.changeset/tiny-doodles-call.md
+++ b/.changeset/tiny-doodles-call.md
@@ -1,0 +1,7 @@
+---
+"@proconnect-gouv/proconnect.identite.database": minor
+---
+
+🚀 Ajout d'un index composite sur les connexions des utilisateurs
+
+Ajoute un index `(user_id, created_at DESC)` sur la table `users_oidc_clients` pour accélérer la requête de listing des connexions d'un utilisateur triée par date de création, évitant un parcours séquentiel de la table.

--- a/migrations/1781180683383_add-user-id-created-at-index-to-users-oidc-clients.ts
+++ b/migrations/1781180683383_add-user-id-created-at-index-to-users-oidc-clients.ts
@@ -1,0 +1,14 @@
+import type { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  await pgm.db.query(`
+CREATE INDEX idx_users_oidc_clients_user_id_created_at
+  ON users_oidc_clients (user_id, created_at DESC);
+`);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  await pgm.db.query(`
+DROP INDEX IF EXISTS idx_users_oidc_clients_user_id_created_at;
+`);
+}

--- a/packages/database/schema.sql
+++ b/packages/database/schema.sql
@@ -74,6 +74,8 @@ DROP INDEX IF EXISTS "public"."index_organizations_on_siret";
 
 DROP INDEX IF EXISTS "public"."index_authenticators_on_credential_id";
 
+DROP INDEX IF EXISTS "public"."idx_users_oidc_clients_user_id_created_at";
+
 ALTER TABLE IF EXISTS ONLY "public"."users"
 DROP CONSTRAINT IF EXISTS "users_pkey";
 
@@ -546,6 +548,11 @@ ADD CONSTRAINT "users_organizations_pkey" PRIMARY KEY ("user_id", "organization_
 --
 ALTER TABLE ONLY "public"."users"
 ADD CONSTRAINT "users_pkey" PRIMARY KEY ("id");
+
+--
+-- Name: idx_users_oidc_clients_user_id_created_at; Type: INDEX; Schema: public; Owner: -
+--
+CREATE INDEX "idx_users_oidc_clients_user_id_created_at" ON "public"."users_oidc_clients" USING "btree" ("user_id", "created_at" DESC);
 
 --
 -- Name: index_authenticators_on_credential_id; Type: INDEX; Schema: public; Owner: -

--- a/packages/database/src/drizzle/schema.ts
+++ b/packages/database/src/drizzle/schema.ts
@@ -3,6 +3,7 @@ import {
   bigint,
   boolean,
   foreignKey,
+  index,
   integer,
   pgTable,
   primaryKey,
@@ -236,6 +237,11 @@ export const users_oidc_clients = pgTable(
     user_ip_address: varchar(),
   },
   (table) => [
+    index("idx_users_oidc_clients_user_id_created_at").using(
+      "btree",
+      table.user_id.asc().nullsLast().op("int4_ops"),
+      table.created_at.desc().nullsFirst().op("int4_ops"),
+    ),
     foreignKey({
       columns: [table.user_id],
       foreignColumns: [users.id],


### PR DESCRIPTION
The connections listing query filters on user_id and orders by created_at DESC, but the table only has an index on its primary key id. The composite index lets PostgreSQL satisfy both the WHERE and the ORDER BY from a single index scan, avoiding a sequential scan and an in-memory sort as the table grows.