### PR TITLE
🐛 (annuaire service public): exclude falsy emails from results

### DIFF
--- a/src/connectors/api-annuaire-service-public.ts
+++ b/src/connectors/api-annuaire-service-public.ts
@@ -7,9 +7,7 @@ import {
 } from "../config/env";
 import {
   ApiAnnuaireConnectionError,
-  ApiAnnuaireInvalidEmailError,
   ApiAnnuaireNotFoundError,
-  ApiAnnuaireTooManyResultsError,
 } from "../config/errors";
 import { logger } from "../services/log";
 import { FetchError, request } from "./request";
@@ -24,7 +22,7 @@ type ApiAnnuaireServicePublicReponse = {
       valeur: string;
     }[];
     nom: string;
-    adresse_courriel?: string;
+    adresse_courriel?: string | null;
     pivot: {
       type_service_local: string;
     }[];
@@ -46,7 +44,6 @@ type ApiAnnuaireServicePublicReponse = {
 
 export const getAnnuaireServicePublicContactEmails = async (
   codeOfficielGeographique: string | null,
-  codePostal: string | null,
 ): Promise<string[]> => {
   if (isEmpty(codeOfficielGeographique)) {
     throw new ApiAnnuaireNotFoundError();
@@ -79,45 +76,36 @@ export const getAnnuaireServicePublicContactEmails = async (
     throw e;
   }
 
-  if (features.length === 0) {
-    throw new ApiAnnuaireNotFoundError(
-      `No mairie found for codeOfficielGeographique: ${codeOfficielGeographique}.`,
-    );
-  }
-
-  if (features.length === 1) {
-    const formattedEmail = extractFormattedEmailFromFeature(features[0]);
-    return [formattedEmail];
-  }
-
-  if (isEmpty(codePostal)) {
-    throw new ApiAnnuaireTooManyResultsError(
-      `Without postal code, we cannot choose a mairie between ${features.length} results.`,
-    );
-  }
-
-  return uniq(
-    features.map((feature) => extractFormattedEmailFromFeature(feature)),
+  const formattedEmails = uniq(
+    features
+      .map((feature) => extractFormattedEmailFromFeature(feature))
+      .filter(isString),
   );
+
+  if (formattedEmails.length === 0) {
+    throw new ApiAnnuaireNotFoundError(
+      `No valid email found for: ${codeOfficielGeographique}.`,
+      {
+        cause: features,
+      },
+    );
+  }
+
+  return formattedEmails;
 };
 
 function extractFormattedEmailFromFeature(
   feature: ApiAnnuaireServicePublicReponse["results"][number],
-): string {
+) {
   const { adresse_courriel } = feature;
-  if (!isString(adresse_courriel)) {
-    throw new ApiAnnuaireInvalidEmailError(
-      `${adresse_courriel} is not a string.`,
-    );
-  }
+
+  if (!adresse_courriel) return;
+
+  if (!isString(adresse_courriel)) return;
 
   const [formattedEmail] = adresse_courriel.toLowerCase().trim().split(";");
 
-  if (!isEmailValid(formattedEmail)) {
-    throw new ApiAnnuaireInvalidEmailError(
-      `${formattedEmail} is not a valid email address.`,
-    );
-  }
+  if (!isEmailValid(formattedEmail)) return;
 
   if (!FEATURE_USE_ANNUAIRE_EMAILS) {
     logger.info(

--- a/src/controllers/user/official-contact-ask-which-email.ts
+++ b/src/controllers/user/official-contact-ask-which-email.ts
@@ -36,7 +36,6 @@ export const getOfficialContactAskWhichEmailController = async (
 
     const contactEmails = await getAnnuaireServicePublicContactEmails(
       organization.cached_code_officiel_geographique,
-      organization.cached_code_postal,
     );
 
     return res.render("user/official-contact-ask-which-email", {

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -313,7 +313,6 @@ export const joinOrganization = async ({
     try {
       contactEmails = await getAnnuaireServicePublicContactEmails(
         organization.cached_code_officiel_geographique,
-        organization.cached_code_postal,
       );
     } catch (err) {
       logger.error(inspect(err, { depth: 3 }));

--- a/src/managers/organization/official-contact-email-verification.ts
+++ b/src/managers/organization/official-contact-email-verification.ts
@@ -42,7 +42,6 @@ export const isCommuneWithMultipleOfficialContactEmails = async (
 
   const contactEmails = await getAnnuaireServicePublicContactEmails(
     organization.cached_code_officiel_geographique,
-    organization.cached_code_postal,
   );
 
   return contactEmails.length > 1;
@@ -83,7 +82,6 @@ export const sendOfficialContactEmailVerificationEmail = async ({
 
   const {
     cached_code_officiel_geographique,
-    cached_code_postal,
     siret,
     cached_libelle: libelle,
   } = organization;
@@ -96,7 +94,6 @@ export const sendOfficialContactEmailVerificationEmail = async ({
     ) {
       const contactEmails = await getAnnuaireServicePublicContactEmails(
         cached_code_officiel_geographique,
-        cached_code_postal,
       );
       if (contactEmails.length > 1) {
         if (!selectedContactEmail) {


### PR DESCRIPTION
**Problem**

When `adresse_courriel` is falsy, the extractor was returning an empty string `""` which got included in the results array, producing invalid email entries.

**Proposal**

Return `undefined` from `extractFormattedEmailFromFeature` when the field is falsy, then filter with `isString` at the call sites so only valid strings reach the output.