### PR TITLE
🔒 Restrict token endpoint authentication methods

### DIFF
--- a/src/config/oidc-provider.ts
+++ b/src/config/oidc-provider.ts
@@ -122,6 +122,10 @@ export const oidcProviderConfiguration = ({
     // This scope will be deprecated
     is_service_public: ["is_service_public"],
   },
+  clientAuthMethods: ["client_secret_post", "private_key_jwt"],
+  clientDefaults: {
+    token_endpoint_auth_method: "client_secret_post",
+  },
   extraParams: ["sp_name", "siret_hint"],
   features: {
     claimsParameter: { enabled: true },


### PR DESCRIPTION
**Problem**

The OIDC configuration supports `none` as a token endpoint authentication method by default, allowing clients to initiate a connection without providing a `client_secret`.

**Proposal**

Restrict the supported authentication methods to `client_secret_post` and `private_key_jwt` to prevent this scenario.

This also aligns the configuration with PCF.