### PR TITLE
🐛 Prevent users from spamming email verification codes

### DIFF
--- a/assets/js/form-validation.js
+++ b/assets/js/form-validation.js
@@ -2,7 +2,9 @@ document.addEventListener("DOMContentLoaded", function () {
   var forms = document.querySelectorAll("form");
 
   forms.forEach(function (form) {
-    var submitButton = form.querySelector("button.fr-btn");
+    var submitButton = form.querySelector(
+      "button.fr-btn:not(.disabled-with-countdown)",
+    );
 
     if (!submitButton) {
       return;

--- a/cypress/e2e/signin_with_email_verification/index.cy.ts
+++ b/cypress/e2e/signin_with_email_verification/index.cy.ts
@@ -26,6 +26,9 @@ describe("sign-in with email verification renewal", () => {
 
     cy.login("rogal.dorn@imperialfists.world");
 
+    // Wait for form-validation.js to attempt to enable buttons on the page.
+    cy.wait(500);
+
     cy.get('[action="/users/send-email-verification"]')
       .contains("Recevoir un nouveau code")
       .should("be.disabled");

--- a/src/managers/session/authenticated.ts
+++ b/src/managers/session/authenticated.ts
@@ -256,9 +256,9 @@ export async function getCurrentIAL(req: Request) {
 
 // get the current Authentication Assurance Level
 // 0: Simple (mot de passe)
-// 1: MFA (auto-géré)
-// 2. MFA (géré par l'organisation) (not available yet)
-// 3. MFA matérielle (géré par l'organisation) (not available yet)
+// 1: MFA faible
+// 2. MFA forte (not available yet)
+// 3. MFA forte matérielle (not available yet)
 export async function getCurrentAAL(req: Request) {
   const currentAmrValues = req.session.amr!;
 

--- a/src/middlewares/rate-limiter.ts
+++ b/src/middlewares/rate-limiter.ts
@@ -104,6 +104,16 @@ export const resetPasswordRateLimiter = new RateLimiterRedis({
   duration: 15 * 60, // per 15 minutes per email
 });
 
+export const sendEmailVerificationRateLimiterMiddleware =
+  emailRateLimiterMiddlewareFactory(
+    new RateLimiterRedis({
+      storeClient: redisClient,
+      keyPrefix: "rate-limiter-send-email-verification",
+      points: 5, // 5 requests
+      duration: 15 * 60, // per 15 minutes per email
+    }),
+  );
+
 export const sendMagicLinkRateLimiterMiddleware =
   emailRateLimiterMiddlewareFactory(
     new RateLimiterRedis({

--- a/src/routers/user.ts
+++ b/src/routers/user.ts
@@ -110,6 +110,7 @@ import {
   officialContactEmailVerificationRateLimiterMiddleware,
   passwordRateLimiterMiddleware,
   rateLimiterMiddleware,
+  sendEmailVerificationRateLimiterMiddleware,
   sendMagicLinkRateLimiterMiddleware,
   verifyEmailRateLimiterMiddleware,
 } from "../middlewares/rate-limiter";
@@ -271,6 +272,7 @@ export const userRouter = () => {
     "/send-email-verification",
     userIsConnectedGuardMiddleware,
     csrfProtectionMiddleware,
+    sendEmailVerificationRateLimiterMiddleware,
     postSendEmailVerificationController,
     userSignInRequirementsGuardMiddleware,
     issueSessionOrRedirectController,


### PR DESCRIPTION
**Problem**

https://github.com/proconnect-gouv/proconnect-identite/pull/1837 introduced a regression that allows users to bypass the countdown intended to limit the number of verification codes requested.

The end-to-end test covering this behavior remained green because it only verified that the button was disabled when the page loaded. However, within 100 ms, the form validation script re-enabled the button because the form was valid. From the user’s perspective, the button therefore appeared to remain enabled.

**Proposal**

Ensure that the form validation script does not interfere with buttons disabled by a countdown.

**Boy scout**

Rate-limit the total number of verification codes sent to each email address, as is already done for magic-link emails.

Also update the `getCurrentAAL` comment with the latest values proposed in
https://github.com/proconnect-gouv/proconnect-espace-partenaires/pull/367.