### PR TITLE
🔧 Use default environment variables from the `proconnect-test-client` image

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -23,7 +23,6 @@ services:
       CLIENT_ID: client_id
       HOST: http://localhost:3001
       PROVIDER: http://localhost:3000/
-      ACR_VALUES_FOR_MFA: "eidas0-mfa,eidas1-mfa,eidas2,eidas3"
     network_mode: "host"
 
   standard-client:
@@ -37,7 +36,6 @@ services:
       SCOPES: openid email profile organization
       SITE_TITLE: standard-client
       STYLESHEET_URL:
-      ACR_VALUES_FOR_MFA: "eidas0-mfa,eidas1-mfa,eidas2,eidas3"
     network_mode: "host"
 
   proconnect-federation-client:
@@ -55,7 +53,6 @@ services:
       SCOPES: openid uid given_name usual_name email siren siret organizational_unit belonging_population phone chorusdt is_service_public is_public_service
       STYLESHEET_URL:
       USERINFO_SIGNED_RESPONSE_ALG: ES256
-      ACR_VALUES_FOR_MFA: "eidas0-mfa,eidas1-mfa,eidas2,eidas3"
     network_mode: "host"
 
   maildev:


### PR DESCRIPTION
**Problem**

We hard-coded `ACR_VALUES_FOR_MFA` values to prepare the transition to the new ACR definitions.

These values have been the defaults since
https://github.com/proconnect-gouv/proconnect-test-client/pull/202, and we switched to the corresponding image in
https://github.com/proconnect-gouv/proconnect-identite/pull/2006.

The hard-coded values are therefore no longer needed.

**Proposal**

Remove the hard-coded environment variables and rely on the defaults provided by the `proconnect-test-client` Docker image.