### PR TITLE
🔧 Replace non-standard TOTP AMR value

### DIFF
--- a/cypress/e2e/signin_with_totp/index.cy.ts
+++ b/cypress/e2e/signin_with_totp/index.cy.ts
@@ -7,7 +7,7 @@ describe("sign-in with TOTP on untrusted browser", () => {
 
     cy.mfaLogin("unused1@yopmail.com");
 
-    cy.contains('"amr": [\n    "pwd",\n    "totp",\n    "mfa"\n  ],');
+    cy.contains('"amr": [\n    "pwd",\n    "otp",\n    "mfa"\n  ],');
   });
 
   it("should sign-in with password and no TOTP", function () {
@@ -31,7 +31,7 @@ describe("sign-in with TOTP on untrusted browser", () => {
 
     cy.mfaLogin("lion.eljonson@darkangels.world");
 
-    cy.contains('"amr": [\n    "pwd",\n    "totp",\n    "mfa"\n  ],');
+    cy.contains('"amr": [\n    "pwd",\n    "otp",\n    "mfa"\n  ],');
   });
 
   it("should sign-in with TOTP when forced by SP, password only otherwise", function () {
@@ -52,7 +52,7 @@ describe("sign-in with TOTP on untrusted browser", () => {
 
     cy.mfaLogin("lion.eljonson@darkangels.world");
 
-    cy.contains('"amr": [\n    "pwd",\n    "totp",\n    "mfa"\n  ],');
+    cy.contains('"amr": [\n    "pwd",\n    "otp",\n    "mfa"\n  ],');
   });
 
   it("should only show totp step when already logged", function () {
@@ -71,7 +71,7 @@ describe("sign-in with TOTP on untrusted browser", () => {
 
     cy.fillTotpFields();
 
-    cy.contains('"amr": [\n    "pwd",\n    "totp",\n    "mfa"\n  ],');
+    cy.contains('"amr": [\n    "pwd",\n    "otp",\n    "mfa"\n  ],');
   });
 
   it("should display error message", function () {
@@ -100,6 +100,6 @@ describe("sign-in with TOTP on untrusted browser", () => {
 
     cy.fillTotpFields();
 
-    cy.contains('"amr": [\n    "pwd",\n    "totp",\n    "mfa"\n  ],');
+    cy.contains('"amr": [\n    "pwd",\n    "otp",\n    "mfa"\n  ],');
   });
 });

--- a/src/managers/session/authenticated.ts
+++ b/src/managers/session/authenticated.ts
@@ -220,6 +220,10 @@ export const getSessionStandardizedAuthenticationMethodsReferences = (
     amr === "email-link" ? "mail" : amr,
   );
 
+  standardizedAmr = standardizedAmr.map((amr) =>
+    amr === "totp" ? "otp" : amr,
+  );
+
   return standardizedAmr;
 };
 

--- a/src/types/express-session.d.ts
+++ b/src/types/express-session.d.ts
@@ -21,12 +21,12 @@ export type AmrValue =
   // Standard values are described here https://datatracker.ietf.org/doc/html/rfc8176#section-2
   | "hwk"
   | "pwd"
-  | "totp"
   | "pop"
   | "mfa"
   // "email-link" is described as "mail" here https://docs.partenaires.franceconnect.gouv.fr/fs/fs-technique/fs-technique-amr/
   | "email-link"
-  // "email-otp" and "uv" is used in ProConnect Identité for internal usage
+  // The following values are used in ProConnect Identité for internal usage
+  | "totp"
   | "email-otp"
   | "uv";
 


### PR DESCRIPTION
**Problem**

When a user authenticates with TOTP, we return `totp` as an authentication method reference in the OIDC `amr` claim.

This value is not standardized, despite the existing comment stating otherwise.  RFC 8176 defines `otp`, but not `totp`: https://datatracker.ietf.org/doc/html/rfc8176#section-2.

This typo dates back to the introduction of the feature: https://github.com/proconnect-gouv/proconnect-identite/commit/c7722b87943fc064c1020bcb8f2e3b02203c315e.

**Proposal**

Use `otp` instead of `totp`, as specified by RFC 8176.