### PR TITLE
📝 Update the FranceConnect page

### DIFF
--- a/src/views/user/franceconnect.ejs
+++ b/src/views/user/franceconnect.ejs
@@ -11,18 +11,18 @@
   <% } else { %>
   <h1 class="fr-h3">Vérifier votre identité</h1>
 
-  <p class="fr-badge fr-badge--new fr-mb-2w">Nouvelle vérification de sécurité</p>
+  <p class="fr-badge fr-badge--purple-glycine fr-mb-2w">Vérification via FranceConnect</p>
 
   <p>
-    Vérifier votre identité avec <b>FranceConnect</b> pour
-    <b>renforcer la protection de votre compte</b>
-    et garantir la sécurité des services auxquels vous accédez.
+    Pour sécuriser votre compte, <b>nous vérifions votre identité via FranceConnect tous les 3 mois</b>.
   </p>
   <p>
-    <i>
-      Cette vérification est demandée lors de votre première connexion,
-      puis une fois tous les 3 mois.
-    </i>
+    Seules vos informations d’identité (nom, prénom, date et ville de naissance) nous sont transmises.
+  </p>
+  <p>
+    <b>
+      Nous n’aurons jamais accès aux autres données de vos comptes (impots.gouv.fr, Améli, etc.).
+    </b>
   </p>
   <% } %>
   <form


### PR DESCRIPTION
**Problem**

The FranceConnect page does not include reassurance messaging explaining that ProConnect will not have access to data provided by FranceConnect identity providers, even though this content was designed some time ago.

**Proposal**

Update the page to match the approved design.

**Screenshots**

Before:

<img width="1354" height="933" alt="image" src="https://github.com/user-attachments/assets/16051ef8-4b1e-4cac-9d12-4ad3671a2574" />

After:

<img width="1357" height="936" alt="image" src="https://github.com/user-attachments/assets/c69248e4-f6b5-4347-a387-81437141682f" />
