### PR TITLE
🐛 fix: use correct match key for given_name check

### DIFF
--- a/cypress/e2e/signup_with_certification_dirigeant/index.cy.ts
+++ b/cypress/e2e/signup_with_certification_dirigeant/index.cy.ts
@@ -256,7 +256,7 @@ describe("❎ Bad match", () => {
     cy.contains("login_required");
   });
 
-  it("Adrian Volckaert maybe a dirigeant of Herisson", () => {
+  it("Adrian Volckaert maybe a dirigeant of Herisson (mismatch on given_name)", () => {
     cy.title().should("include", "S'inscrire ou se connecter - ");
     cy.magicLinkLogin("adrian.volckaert@yopmail.com");
 
@@ -279,8 +279,57 @@ describe("❎ Bad match", () => {
       "Des discordances ont été détectées entre votre identité FranceConnect (affichée ici) et celle connue du Registre National des Entreprises pour Herisson.",
     );
 
+    cy.contains("Prénom").siblings().contains("Informations discordantes");
+    cy.contains("Nom")
+      .siblings()
+      .should("not.contain", "Informations discordantes");
+    cy.contains("Date de naissance")
+      .siblings()
+      .should("not.contain", "Informations discordantes");
+    cy.contains("Commune de naissance")
+      .siblings()
+      .should("not.contain", "Informations discordantes");
+
     cy.contains("Vérifier sur l’Annuaire des Entreprises");
     cy.contains("Comment corriger les données ?");
+
+    cy.contains("Continuer").click();
+
+    cy.title().should("include", "Error");
+    cy.contains("AuthorizationResponseError");
+    cy.contains("login_required");
+  });
+
+  it("Adrian Volckaert has matching first_name but wrong family_name for Suricate", () => {
+    cy.title().should("include", "S'inscrire ou se connecter - ");
+    cy.magicLinkLogin("adrian.volckaert@yopmail.com");
+
+    cy.title().should("include", "Rejoindre une organisation - ");
+    cy.contains("SIRET de l’organisation que vous représentez").click();
+    cy.focused().clear().type("52169091700021");
+    cy.getByLabel(
+      "Organisation correspondante au SIRET donné : Suricate - The kilberry",
+    ).click();
+
+    cy.title().should("include", "Certification dirigeant -");
+    cy.getByLabel("S’identifier avec FranceConnect").click();
+
+    cy.title().should("include", "Connexion 🎭 FranceConnect 🎭");
+    cy.contains("Je suis Adrian Volckaert").click();
+
+    cy.title().should("include", "Certification impossible -");
+    cy.contains("Impossible de vous certifier ⚠️");
+
+    cy.contains("Prénom")
+      .siblings()
+      .should("not.contain", "Informations discordantes");
+    cy.contains("Nom").siblings().contains("Informations discordantes");
+    cy.contains("Date de naissance")
+      .siblings()
+      .should("not.contain", "Informations discordantes");
+    cy.contains("Commune de naissance")
+      .siblings()
+      .should("not.contain", "Informations discordantes");
 
     cy.contains("Continuer").click();
 

--- a/packages/testing/src/api/routes/registre-national-entreprises.inpi.fr/companies/521690917.json
+++ b/packages/testing/src/api/routes/registre-national-entreprises.inpi.fr/companies/521690917.json
@@ -1,0 +1,42 @@
+{
+  "id": "🎭 RNE SURICATE Company ID",
+  "siren": "521690917",
+  "formality": {
+    "content": {
+      "personneMorale": {
+        "composition": {
+          "pouvoirs": [
+            {
+              "typeDePersonne": "INDIVIDU",
+              "actif": true,
+              "individu": {
+                "descriptionPersonne": {
+                  "dateDeNaissance": "1979-11-12",
+                  "nom": "Cheron",
+                  "prenoms": ["Stevens"],
+                  "genre": "1"
+                }
+              }
+            },
+            {
+              "typeDePersonne": "INDIVIDU",
+              "actif": true,
+              "individu": {
+                "descriptionPersonne": {
+                  "dateDeNaissance": "1984-06-05",
+                  "nom": "DURAND",
+                  "prenoms": ["ADRIAN"],
+                  "genre": "1",
+                  "lieuDeNaissance": "75111",
+                  "codePostalNaissance": "75011",
+                  "paysNaissance": "FRANCE"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "diffusionINSEE": "O"
+  }
+}

--- a/src/views/certification-dirigeant/close-match-error.ejs
+++ b/src/views/certification-dirigeant/close-match-error.ejs
@@ -5,8 +5,8 @@
   <p>Des discordances ont été détectées entre votre identité <b>FranceConnect</b> (affichée ici) et celle connue du <b><%= dataSourceLabel; %></b> pour <b><%= organization_label; %></b>.
 
 
-  <div class="fr-pl-1w <%= locals.matches.has('given_name') ? '' : 'info-mismatch' %>">
-    <% if (!locals.matches.has('given_name')) { %>
+  <div class="fr-pl-1w <%= locals.matches.has('first_name') ? '' : 'info-mismatch' %>">
+    <% if (!locals.matches.has('first_name')) { %>
       <p class="fr-badge fr-badge--warning">Informations discordantes</p>
     <% } %>
     <p class="fr-mb-0 fr-text--sm">


### PR DESCRIPTION
**Problem**

The close-match-error view checked `matches.has('given_name')` but `MatchCriteria` uses `'first_name'` as the key. The mismatch badge for Prénom was never shown even when the first name didn't match.

**Proposal**

Align the template to check `'first_name'` to match the enum value emitted by `certification-score.ts`.