### PR TITLE
📝 Update the `mail` AMR definition

### DIFF
--- a/cypress/e2e/signin_with_totp/index.cy.ts
+++ b/cypress/e2e/signin_with_totp/index.cy.ts
@@ -71,7 +71,9 @@ describe("sign-in with TOTP on untrusted browser", () => {
 
     cy.fillTotpFields();
 
-    cy.contains('"amr": [\n    "pwd",\n    "otp",\n    "mfa"\n  ],');
+    cy.contains(
+      '"amr": [\n    "pwd",\n    "mail",\n    "otp",\n    "mfa"\n  ],',
+    );
   });
 
   it("should display error message", function () {
@@ -100,6 +102,8 @@ describe("sign-in with TOTP on untrusted browser", () => {
 
     cy.fillTotpFields();
 
-    cy.contains('"amr": [\n    "pwd",\n    "otp",\n    "mfa"\n  ],');
+    cy.contains(
+      '"amr": [\n    "pwd",\n    "mail",\n    "otp",\n    "mfa"\n  ],',
+    );
   });
 });

--- a/src/managers/session/authenticated.ts
+++ b/src/managers/session/authenticated.ts
@@ -212,17 +212,18 @@ export const getSessionStandardizedAuthenticationMethodsReferences = (
 
   let standardizedAmr: string[] = [...req.session.amr];
 
-  standardizedAmr = standardizedAmr.filter(
-    (amr) => amr !== "uv" && amr !== "email-otp",
-  );
+  standardizedAmr = standardizedAmr.filter((amr) => amr !== "uv");
 
   standardizedAmr = standardizedAmr.map((amr) =>
-    amr === "email-link" ? "mail" : amr,
+    amr === "email-link" || amr === "email-otp" ? "mail" : amr,
   );
 
   standardizedAmr = standardizedAmr.map((amr) =>
     amr === "totp" ? "otp" : amr,
   );
+
+  // remove duplicate values
+  standardizedAmr = [...new Set(standardizedAmr)];
 
   return standardizedAmr;
 };


### PR DESCRIPTION
**Problem**

The `mail` AMR does not have the same definition as in the FranceConnect AMR documentation, despite explicitly referring to it.

Additionally, this AMR is currently used in ProConnect Identité only for magic-link authentication, even though its definition also covers email OTP authentication.

**Proposal**

Align the `mail` AMR definition with the FranceConnect definition.

Also add the `mail` AMR when a user authenticates with an email OTP.

Refers to: https://github.com/proconnect-gouv/proconnect-espace-partenaires/pull/389