### PR TITLE
🐛 Fix anonymized copy of authenticators table

### DIFF
--- a/.github/workflows/anonymized-copy.yml
+++ b/.github/workflows/anonymized-copy.yml
@@ -1,0 +1,74 @@
+name: 🕵️ Anonymized copy script test
+
+on:
+  push:
+    paths:
+      - scripts/create-anonymized-copy-of-database.sh
+      - .github/workflows/anonymized-copy.yml
+
+env:
+  DATABASE_URL: postgres://proconnect-identite:proconnect-identite@127.0.0.1:5432/proconnect-identite
+  PGDATABASE: proconnect-identite
+  PGHOST: 127.0.0.1
+  PGPASSWORD: proconnect-identite
+  PGPORT: 5432
+  PGUSER: proconnect-identite
+
+jobs:
+  test:
+    name: 🧪 Run the script against a real postgres
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17.9
+        env:
+          POSTGRES_USER: ${{ env.PGUSER }}
+          POSTGRES_PASSWORD: ${{ env.PGPASSWORD }}
+          POSTGRES_DB: ${{ env.PGDATABASE }}
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          cache: "npm"
+          node-version-file: package.json
+      # pg_dump must match the server major version; ubuntu-latest ships client 16
+      - name: 🐘 Install postgresql-client-17
+        run: sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y && sudo apt-get install -y postgresql-client-17
+      - name: 📦 Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+          NPM_CONFIG_AUDIT: false
+          NPM_CONFIG_FUND: false
+          NPM_CONFIG_UPDATE_NOTIFIER: false
+      - name: 🏗️ Build workspaces
+        run: npm run build:workspaces
+      - name: 🗃️ Migrate database
+        run: npm run migrate up
+      - name: 🌱 Load fixtures
+        run: npm run fixtures:load-ci -- scripts/fixtures.sql
+      - name: 🎯 Create metabase database
+        run: |
+          psql --dbname=postgres --command="CREATE DATABASE metabase"
+          # the script grants SELECT to this role at the end, as in production
+          psql --dbname=postgres --command="CREATE ROLE metabase"
+      - name: 🕵️ Create the anonymized copy
+        run: sh scripts/create-anonymized-copy-of-database.sh
+        env:
+          APP: proconnect-identite
+          SCALINGO_POSTGRESQL_URL: postgres://proconnect-identite:proconnect-identite@127.0.0.1:5432/proconnect-identite
+          METABASE_DB_URL: postgres://proconnect-identite:proconnect-identite@127.0.0.1:5432/metabase
+      - name: 🔍 Check each copied table has the same row count as the source
+        run: |
+          for table in users organizations email_domains franceconnect_userinfo authenticators moderations oidc_clients users_oidc_clients users_organizations; do
+            src=$(psql --dbname=proconnect-identite --tuples-only --no-align --command="SELECT count(*) FROM $table")
+            dest=$(psql --dbname=metabase --tuples-only --no-align --command="SELECT count(*) FROM $table")
+            if [ "$src" = "$dest" ]; then
+              echo "✅ $table: $src rows copied"
+            else
+              echo "::error::❌ $table: expected $src rows in the anonymized copy, found $dest"
+              exit 1
+            fi
+          done

--- a/.github/workflows/anonymized-copy.yml
+++ b/.github/workflows/anonymized-copy.yml
@@ -6,6 +6,9 @@ on:
       - scripts/create-anonymized-copy-of-database.sh
       - .github/workflows/anonymized-copy.yml
 
+permissions:
+  contents: read
+
 env:
   DATABASE_URL: postgres://proconnect-identite:proconnect-identite@127.0.0.1:5432/proconnect-identite
   PGDATABASE: proconnect-identite

--- a/scripts/create-anonymized-copy-of-database.sh
+++ b/scripts/create-anonymized-copy-of-database.sh
@@ -141,17 +141,17 @@ echo "$(logPrefix) Creating anonymized copy of table authenticators..."
 psql $SRC_DB_URL -c "
 CREATE TABLE tmp_authenticators AS
 SELECT
-  credential_device_type
-  credential_backed_up
-  transports
-  user_id
-  display_name
-  created_at
-  last_used_at
-  usage_count
+  credential_device_type,
+  credential_backed_up,
+  transports,
+  user_id,
+  display_name,
+  created_at,
+  last_used_at,
+  usage_count,
   user_verified
 FROM authenticators"
-psql $SRC_DB_URL --command="ALTER TABLE tmp_authenticators ADD PRIMARY KEY (user_id)"
+psql $SRC_DB_URL --command="CREATE INDEX ON tmp_authenticators (user_id)"
 pg_dump --no-owner --table=tmp_authenticators $SRC_DB_URL | psql $DEST_DB_URL
 psql $DEST_DB_URL --command="ALTER TABLE tmp_authenticators RENAME TO authenticators"
 psql $SRC_DB_URL --command="DROP TABLE IF EXISTS tmp_authenticators"


### PR DESCRIPTION
**Problem**

The authenticators copy block added in #1967 fails in production: the SELECT column list has no commas, so psql errors with "syntax error at or near transports". The following ADD PRIMARY KEY (user_id) would also fail, since a user can register several authenticators and the real key, credential_id, is intentionally excluded from the anonymized copy.

**Proposal**

Add the missing commas and replace the primary key with a plain non-unique index on user_id, kept for Metabase query performance and carried over by pg_dump.

Refs #1967