### PR TITLE
🍱 Sync annuaire 50041 fixture with real API

### DIFF
--- a/packages/testing/src/api/routes/api-lannuaire.service-public.fr/records/50041.json
+++ b/packages/testing/src/api/routes/api-lannuaire.service-public.fr/records/50041.json
@@ -1,5 +1,5 @@
 {
-  "total_count": 4,
+  "total_count": 2,
   "results": [
     {
       "nom": "Mairie - La Hague",
@@ -8,20 +8,8 @@
       "adresse": "[]"
     },
     {
-      "nom": "Mairie déléguée - Éculleville",
-      "adresse_courriel": "mairie-eculleville@lahague.com",
-      "code_insee_commune": "50041",
-      "adresse": "[]"
-    },
-    {
       "nom": "Mairie déléguée - Beaumont-Hague",
       "adresse_courriel": "mairie-beaumont@lahague.com",
-      "code_insee_commune": "50041",
-      "adresse": "[]"
-    },
-    {
-      "nom": "Mairie déléguée - Acqueville",
-      "adresse_courriel": "mairie-acqueville@lahague.com",
       "code_insee_commune": "50041",
       "adresse": "[]"
     }


### PR DESCRIPTION
**Problem**

The daily drift check found the La Hague (50041) mocked record out of sync: the real API dropped the Éculleville and Acqueville mairies.

**Proposal**

Regenerate the fixture (4 → 2 mairies). Two distinct emails remain, so the mairie selection page in the
join_with_code_sent_to_official_contact_email e2e spec stays reachable with no spec change.

Closes #2034