### PR TITLE
💬 fix: remove typo from email verification template

### DIFF
--- a/.changeset/tall-pandas-stop.md
+++ b/.changeset/tall-pandas-stop.md
@@ -1,0 +1,5 @@
+---
+"@proconnect-gouv/proconnect.email": patch
+---
+
+suppression d'une typo dans l'email de vérification d'adresse e-mail

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -120,7 +120,7 @@ function verifyEmailCommand() {
       cy.maildevVisitMessageById(email.id);
       cy.origin("http://localhost:1080", () => {
         cy.contains(
-          "Pour vérifier votre adresse e-mail, merci de de copier-coller ou de renseigner ce code dans l’interface de connexion ProConnect.",
+          "Pour vérifier votre adresse e-mail, merci de copier-coller ou de renseigner ce code dans l’interface de connexion ProConnect.",
         );
       });
       cy.go("back");

--- a/packages/email/src/VerifyEmail.test.tsx.snapshot
+++ b/packages/email/src/VerifyEmail.test.tsx.snapshot
@@ -148,8 +148,8 @@ exports[`VerifyEmail > should render 1`] = `
                                     "
                                   >
                                     Pour vérifier votre adresse e-mail, merci de
-                                    de copier-coller ou de renseigner ce code
-                                    dans l’interface de connexion ProConnect.<br /><em
+                                    copier-coller ou de renseigner ce code dans
+                                    l’interface de connexion ProConnect.<br /><em
                                       style="
                                         color: #000091;
                                         font-family:

--- a/packages/email/src/VerifyEmail.tsx
+++ b/packages/email/src/VerifyEmail.tsx
@@ -12,7 +12,7 @@ export default function VerifyEmail(props: Props) {
       <Text>Bonjour,</Text>
       <br />
       <Text>
-        Pour vérifier votre adresse e-mail, merci de de copier-coller ou de
+        Pour vérifier votre adresse e-mail, merci de copier-coller ou de
         renseigner ce code dans l’interface de connexion ProConnect.
         <br />
         <Em>Ce code est valable 1h.</Em>


### PR DESCRIPTION
**Problem**
The email verification template contained an extra word, resulting in an incorrect message.

**Proposal**
Remove the unnecessary word from the email verification template.