### PR TITLE
💬 fix: clarify verification email wording

### DIFF
--- a/cypress/e2e/signin_with_email_verification/index.cy.ts
+++ b/cypress/e2e/signin_with_email_verification/index.cy.ts
@@ -14,9 +14,7 @@ describe("sign-in with email verification renewal", () => {
       "Information : pour garantir la sécurité de votre compte, nous avons besoin d’authentifier votre navigateur.",
     );
 
-    cy.contains(
-      "Vérifiez les emails envoyés par lion.eljonson@darkangels.world",
-    );
+    cy.contains("Vérifiez les emails envoyés à lion.eljonson@darkangels.world");
 
     cy.verifyEmail();
 
@@ -44,9 +42,7 @@ describe("sign-in with email verification renewal", () => {
       .contains("Recevoir un nouveau code")
       .click();
 
-    cy.contains(
-      "Vérifiez les emails envoyés par rogal.dorn@imperialfists.world",
-    );
+    cy.contains("Vérifiez les emails envoyés à rogal.dorn@imperialfists.world");
 
     cy.verifyEmail();
 

--- a/cypress/e2e/signin_with_suggestion/index.cy.ts
+++ b/cypress/e2e/signin_with_suggestion/index.cy.ts
@@ -50,7 +50,7 @@ describe("sign-in with suggestion", () => {
     cy.contains("Continuer").click();
 
     cy.title().should("equal", "Vérifier votre email - ProConnect");
-    cy.contains("Vérifiez les emails envoyés par user@intradef.gouv.fr.");
+    cy.contains("Vérifiez les emails envoyés à user@intradef.gouv.fr.");
 
     cy.verifyEmail();
 

--- a/src/views/user/verify-email.ejs
+++ b/src/views/user/verify-email.ejs
@@ -15,7 +15,7 @@
             <% if (codeSent || newCodeSent) { %>
                 <div class="fr-alert fr-alert--info fr-mb-4w">
                     <h2 class="fr-h6">Code de vérification envoyé</h2>
-                    <p>Vérifiez les emails envoyés par <b><%= email; %></b>.
+                    <p>Vérifiez les emails envoyés à <b><%= email; %></b>.
                     </p>
                 </div>
             <% } %>


### PR DESCRIPTION
**Problem**
The wording around the verification email caused confusion about whether it referred to the sender's email address or the recipient's email address.

**Proposal**
Update the wording to clearly distinguish the role of the sender and recipient email addresses.