### PR TITLE
♻️ refactor: remove unused baseurl email template parameter

### DIFF
--- a/.changeset/lazy-lands-teach.md
+++ b/.changeset/lazy-lands-teach.md
@@ -1,0 +1,5 @@
+---
+"@proconnect-gouv/proconnect.email": minor
+---
+
+suppression du paramètre baseurl passé à tous les templates de mails

--- a/packages/email/CONTRIBUTING.md
+++ b/packages/email/CONTRIBUTING.md
@@ -50,13 +50,9 @@ touch src/MyNewTemplate.test.tsx
 ```typescript
 // 1. Component with typed props
 export default function MyNewTemplate(props: Props) {
-  const { baseurl, ...otherProps } = props;
-  return <Layout baseurl={baseurl}>...</Layout>
+  return <Layout>...</Layout>
 }
 
-export type Props = LayoutProps & {
-  // Add component-specific props here
-};
 
 // 2. Storybook story with realistic data
 import type { ComponentAnnotations, Renderer } from "@storybook/csf";
@@ -66,7 +62,6 @@ export default {
   title: "My New Template",
   render: MyNewTemplate,
   args: {
-    baseurl: "http://localhost:3000",
     /* ... realistic test data ... */
   } satisfies Props,
 } as ComponentAnnotations<Renderer, Props>;

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -29,7 +29,6 @@ const info = await transporter.sendMail({
   to: "user@example.com",
   subject: "[ProConnect] Delete free TOTP",
   html: DeleteFreeTotpMail({
-    baseurl: "https://identite.proconnect.gouv.fr",
     given_name: "Marie",
     family_name: "Dupont",
     support_email: "support@example.com",

--- a/packages/email/src/Add2fa.stories.tsx
+++ b/packages/email/src/Add2fa.stories.tsx
@@ -9,7 +9,6 @@ export default {
   title: "Add 2FA",
   render: Add2fa,
   args: {
-    baseurl: "http://localhost:3000",
     email: "marie.dupont@example.com",
     family_name: "Dupont",
     given_name: "Marie",

--- a/packages/email/src/Add2fa.tsx
+++ b/packages/email/src/Add2fa.tsx
@@ -1,14 +1,14 @@
 //
 
-import { Layout, type LayoutProps } from "./_layout.js";
+import { Layout } from "./_layout.js";
 import { Text } from "./components/index.js";
 
 //
 
 export default function Add2fa(props: Props) {
-  const { baseurl, email, family_name, given_name } = props;
+  const { email, family_name, given_name } = props;
   return (
-    <Layout baseurl={baseurl}>
+    <Layout>
       <Text safe>
         Bonjour {given_name} {family_name},
       </Text>
@@ -25,7 +25,7 @@ export default function Add2fa(props: Props) {
 
 //
 
-export type Props = LayoutProps & {
+export type Props = {
   email: string;
   family_name: string;
   given_name: string;

--- a/packages/email/src/AddAccessKey.stories.tsx
+++ b/packages/email/src/AddAccessKey.stories.tsx
@@ -11,6 +11,5 @@ export default {
   args: {
     given_name: "Marie",
     family_name: "Dupont",
-    baseurl: "http://localhost:3000",
   } as Props,
 } as ComponentAnnotations<Renderer, Props>;

--- a/packages/email/src/AddAccessKey.tsx
+++ b/packages/email/src/AddAccessKey.tsx
@@ -1,19 +1,19 @@
 //
 
-import { Layout, type LayoutProps } from "./_layout.js";
+import { Layout } from "./_layout.js";
 import { Link, Text } from "./components/index.js";
 
 //
 
 export default function AddAccessKey(props: Props) {
-  const { baseurl, family_name, given_name, support_email } = props;
+  const { family_name, given_name, support_email } = props;
   const mailtoParams = new URLSearchParams({
     subject: "Erreur - Add Access Key",
   });
   const mailtoHref = `mailto:${support_email}?${mailtoParams.toString()}`;
 
   return (
-    <Layout baseurl={baseurl}>
+    <Layout>
       <Text safe>
         Bonjour {given_name} {family_name},
       </Text>
@@ -33,7 +33,7 @@ export default function AddAccessKey(props: Props) {
 
 //
 
-export type Props = LayoutProps & {
+export type Props = {
   family_name: string;
   given_name: string;
   support_email: string;

--- a/packages/email/src/Delete2faProtection.stories.tsx
+++ b/packages/email/src/Delete2faProtection.stories.tsx
@@ -11,6 +11,5 @@ export default {
   args: {
     given_name: "Marie",
     family_name: "Dupont",
-    baseurl: "http://localhost:3000",
   } as Props,
 } as ComponentAnnotations<Renderer, Props>;

--- a/packages/email/src/Delete2faProtection.tsx
+++ b/packages/email/src/Delete2faProtection.tsx
@@ -1,14 +1,14 @@
 //
 
-import { Layout, type LayoutProps } from "./_layout.js";
+import { Layout } from "./_layout.js";
 import { Text } from "./components/index.js";
 
 //
 
 export default function Delete2faProtection(props: Props) {
-  const { baseurl, given_name, family_name } = props;
+  const { given_name, family_name } = props;
   return (
-    <Layout baseurl={baseurl}>
+    <Layout>
       <Text safe>
         Bonjour {given_name} {family_name},
       </Text>
@@ -25,7 +25,7 @@ export default function Delete2faProtection(props: Props) {
 
 //
 
-export type Props = LayoutProps & {
+export type Props = {
   given_name: string;
   family_name: string;
 };

--- a/packages/email/src/DeleteAccessKey.stories.tsx
+++ b/packages/email/src/DeleteAccessKey.stories.tsx
@@ -9,7 +9,6 @@ export default {
   title: "Delete Access Key",
   render: DeleteAccessKey,
   args: {
-    baseurl: "http://localhost:3000",
     family_name: "Dupont",
     given_name: "Marie",
     support_email: "support+identite@proconnect.gouv.fr",

--- a/packages/email/src/DeleteAccessKey.tsx
+++ b/packages/email/src/DeleteAccessKey.tsx
@@ -1,18 +1,18 @@
 //
 
-import { Layout, type LayoutProps } from "./_layout.js";
+import { Layout } from "./_layout.js";
 import { Link, Text } from "./components/index.js";
 
 //
 
 export default function DeleteAccessKey(props: Props) {
-  const { baseurl, family_name, given_name, support_email } = props;
+  const { family_name, given_name, support_email } = props;
   const mailtoParams = new URLSearchParams({
     subject: "Erreur - Delete Access Key",
   });
   const mailtoHref = `mailto:${support_email}?${mailtoParams.toString()}`;
   return (
-    <Layout baseurl={baseurl}>
+    <Layout>
       <Text safe>
         Bonjour {given_name} {family_name},
       </Text>
@@ -33,7 +33,7 @@ export default function DeleteAccessKey(props: Props) {
 
 //
 
-export type Props = LayoutProps & {
+export type Props = {
   family_name: string;
   given_name: string;
   support_email: string;

--- a/packages/email/src/DeleteAccount.stories.tsx
+++ b/packages/email/src/DeleteAccount.stories.tsx
@@ -12,6 +12,5 @@ export default {
     given_name: "Marie",
     family_name: "Dupont",
     support_email: "support+identite@proconnect.gouv.fr",
-    baseurl: "http://localhost:3000",
   },
 } as ComponentAnnotations<Renderer, Props>;

--- a/packages/email/src/DeleteAccount.tsx
+++ b/packages/email/src/DeleteAccount.tsx
@@ -1,18 +1,18 @@
 //
 
-import { Layout, type LayoutProps } from "./_layout.js";
+import { Layout } from "./_layout.js";
 import { Link, Text } from "./components/index.js";
 
 //
 
 export default function DeleteAccount(props: Props) {
-  const { baseurl, given_name, family_name, support_email } = props;
+  const { given_name, family_name, support_email } = props;
   const mailtoParams = new URLSearchParams({
     subject: "Erreur - Delete account",
   });
   const mailtoHref = `mailto:${support_email}?${mailtoParams.toString()}`;
   return (
-    <Layout baseurl={baseurl}>
+    <Layout>
       <Text safe>
         Bonjour {given_name} {family_name},
       </Text>
@@ -37,7 +37,7 @@ export default function DeleteAccount(props: Props) {
 
 //
 
-export type Props = LayoutProps & {
+export type Props = {
   given_name: string;
   family_name: string;
   support_email: string;

--- a/packages/email/src/DeleteFreeTotpMail.stories.tsx
+++ b/packages/email/src/DeleteFreeTotpMail.stories.tsx
@@ -12,6 +12,5 @@ export default {
     given_name: "Marie",
     family_name: "Dupont",
     support_email: "support+identite@proconnect.gouv.fr",
-    baseurl: "http://localhost:3000",
   },
 } as ComponentAnnotations<Renderer, Props>;

--- a/packages/email/src/DeleteFreeTotpMail.tsx
+++ b/packages/email/src/DeleteFreeTotpMail.tsx
@@ -1,18 +1,18 @@
 //
 
-import { Layout, type LayoutProps } from "./_layout.js";
+import { Layout } from "./_layout.js";
 import { Link, Text } from "./components/index.js";
 
 //
 
 export default function DeleteFreeTotpMail(props: Props) {
-  const { baseurl, given_name, family_name, support_email } = props;
+  const { given_name, family_name, support_email } = props;
   const mailtoParams = new URLSearchParams({
     subject: "Erreur - Mon organisation",
   });
   const mailtoHref = `mailto:${support_email}?${mailtoParams.toString()}`;
   return (
-    <Layout baseurl={baseurl}>
+    <Layout>
       <Text safe>
         Bonjour {given_name} {family_name},
       </Text>
@@ -33,7 +33,7 @@ export default function DeleteFreeTotpMail(props: Props) {
 
 //
 
-export type Props = LayoutProps & {
+export type Props = {
   given_name: string;
   family_name: string;
   support_email: string;

--- a/packages/email/src/MagicLink.stories.tsx
+++ b/packages/email/src/MagicLink.stories.tsx
@@ -9,7 +9,6 @@ export default {
   title: "Magic Link",
   render: MagicLink,
   args: {
-    baseurl: "http://localhost:3000",
     magic_link: "#/../src/MagicLink.stories.tsx",
   } as Props,
 } as ComponentAnnotations<Renderer, Props>;

--- a/packages/email/src/MagicLink.tsx
+++ b/packages/email/src/MagicLink.tsx
@@ -1,20 +1,21 @@
 //
 
 import { escapeHtml } from "@kitajs/html";
-import { Layout, type LayoutProps } from "./_layout.js";
+import { Layout } from "./_layout.js";
 import { Button, Em, Text } from "./components/index.js";
 
 //
 
 export default function MagicLink(props: Props) {
-  const { baseurl, magic_link, app_name = "ProConnect" } = props;
+  const { magic_link, app_name = "ProConnect" } = props;
   return (
-    <Layout baseurl={baseurl}>
+    <Layout>
       <Text>Bonjour,</Text>
       <br />
       <Text>
-        Vous avez demandé un <b>lien d'identification</b> à {escapeHtml(app_name)}. Utilisez
-        le bouton ci-dessous pour vous connecter instantanément.
+        Vous avez demandé un <b>lien d'identification</b> à{" "}
+        {escapeHtml(app_name)}. Utilisez le bouton ci-dessous pour vous
+        connecter instantanément.
         <br />
         <Em>Il est valable 1 heure</Em>.
       </Text>
@@ -28,7 +29,7 @@ export default function MagicLink(props: Props) {
 
 //
 
-export type Props = LayoutProps & {
+export type Props = {
   magic_link: string;
   app_name?: string;
 };

--- a/packages/email/src/OfficialContactEmailVerification.tsx
+++ b/packages/email/src/OfficialContactEmailVerification.tsx
@@ -1,15 +1,15 @@
 //
 
-import { Layout, type LayoutProps } from "./_layout.js";
+import { Layout } from "./_layout.js";
 import { Badge, Em, Text } from "./components/index.js";
 
 //
 
 export default function OfficialContactEmailVerification(props: Props) {
-  const { baseurl, given_name, email, family_name, libelle, token } = props;
+  const { given_name, email, family_name, libelle, token } = props;
 
   return (
-    <Layout baseurl={baseurl}>
+    <Layout>
       <Text>Bonjour,</Text>
       <br />
       <Text>
@@ -35,7 +35,7 @@ export default function OfficialContactEmailVerification(props: Props) {
 
 //
 
-export type Props = LayoutProps & {
+export type Props = {
   email: string;
   family_name: string;
   given_name: string;

--- a/packages/email/src/ResetPassword.stories.tsx
+++ b/packages/email/src/ResetPassword.stories.tsx
@@ -10,6 +10,5 @@ export default {
   render: ResetPassword,
   args: {
     reset_password_link: "#/../src/ResetPassword.stories.tsx",
-    baseurl: "http://localhost:3000",
   } as Props,
 } as ComponentAnnotations<Renderer, Props>;

--- a/packages/email/src/ResetPassword.tsx
+++ b/packages/email/src/ResetPassword.tsx
@@ -1,14 +1,14 @@
 //
 
-import { Layout, type LayoutProps } from "./_layout.js";
+import { Layout } from "./_layout.js";
 import { Button, Em, Text } from "./components/index.js";
 
 //
 
 export default function ResetPassword(props: Props) {
-  const { baseurl, reset_password_link } = props;
+  const { reset_password_link } = props;
   return (
-    <Layout baseurl={baseurl}>
+    <Layout>
       <Text safe>Bonjour,</Text>
       <br />
       <Text>
@@ -36,6 +36,6 @@ export default function ResetPassword(props: Props) {
 
 //
 
-export type Props = LayoutProps & {
+export type Props = {
   reset_password_link: string;
 };

--- a/packages/email/src/UpdatePersonalDataMail.stories.tsx
+++ b/packages/email/src/UpdatePersonalDataMail.stories.tsx
@@ -5,14 +5,15 @@ import type {
   Renderer,
   StoryAnnotations,
 } from "@storybook/csf";
-import UpdatePersonalDataMail, { type Props } from "./UpdatePersonalDataMail.js";
+import UpdatePersonalDataMail, {
+  type Props,
+} from "./UpdatePersonalDataMail.js";
 
 //
 export default {
   title: "Update Personal Data",
   render: UpdatePersonalDataMail,
   args: {
-    baseurl: "http://localhost:3000",
     given_name: "Maarie",
     family_name: "Duupont",
     updatedFields: {

--- a/packages/email/src/UpdatePersonalDataMail.tsx
+++ b/packages/email/src/UpdatePersonalDataMail.tsx
@@ -1,12 +1,12 @@
 //
 
-import { Layout, type LayoutProps } from "./_layout.js";
+import { Layout } from "./_layout.js";
 import { Text } from "./components/index.js";
 
 export default function UpdatePersonalDataMail(props: Props) {
-  const { baseurl, family_name, given_name, updatedFields } = props;
+  const { family_name, given_name, updatedFields } = props;
   return (
-    <Layout baseurl={baseurl}>
+    <Layout>
       <Text safe>
         Bonjour {given_name} {family_name},
       </Text>
@@ -51,7 +51,7 @@ export default function UpdatePersonalDataMail(props: Props) {
 
 //
 
-export type Props = LayoutProps & {
+export type Props = {
   family_name: string | null;
   given_name: string | null;
   updatedFields: Partial<{

--- a/packages/email/src/VerifyEmail.stories.tsx
+++ b/packages/email/src/VerifyEmail.stories.tsx
@@ -9,7 +9,6 @@ export default {
   title: "Verify Email",
   render: VerifyEmail,
   args: {
-    baseurl: "http://localhost:3000",
     token: "579687",
   } as Props,
 } as ComponentAnnotations<Renderer, Props>;

--- a/packages/email/src/VerifyEmail.tsx
+++ b/packages/email/src/VerifyEmail.tsx
@@ -1,14 +1,14 @@
 //
 
-import { Layout, type LayoutProps } from "./_layout.js";
+import { Layout } from "./_layout.js";
 import { Badge, Em, Text } from "./components/index.js";
 
 //
 
 export default function VerifyEmail(props: Props) {
-  const { baseurl, token } = props;
+  const { token } = props;
   return (
-    <Layout baseurl={baseurl}>
+    <Layout>
       <Text>Bonjour,</Text>
       <br />
       <Text>
@@ -30,4 +30,4 @@ export default function VerifyEmail(props: Props) {
 
 //
 
-export type Props = LayoutProps & { token: string };
+export type Props = { token: string };

--- a/packages/email/src/Welcome.stories.tsx
+++ b/packages/email/src/Welcome.stories.tsx
@@ -9,7 +9,7 @@ export default {
   title: "Welcome",
   render: Welcome,
   args: {
-    baseurl: "#/../src/Welcome.stories.tsx",
+    base_url: "#/../src/Welcome.stories.tsx",
     family_name: "Dupont",
     given_name: "Marie",
   } as Props,

--- a/packages/email/src/Welcome.tsx
+++ b/packages/email/src/Welcome.tsx
@@ -1,14 +1,14 @@
 //
 
-import { Layout, type LayoutProps } from "./_layout.js";
+import { Layout } from "./_layout.js";
 import { Em, Link, Text } from "./components/index.js";
 
 //
 
 export default function Welcome(props: Props) {
-  const { baseurl, family_name, given_name } = props;
+  const { base_url, family_name, given_name } = props;
   return (
-    <Layout baseurl={baseurl}>
+    <Layout>
       <Text safe>
         Bonjour {given_name} {family_name},
       </Text>
@@ -21,8 +21,8 @@ export default function Welcome(props: Props) {
         <br />
         <br />À tout moment, retrouvez les informations de votre compte
         ProConnect sur{" "}
-        <Link href={baseurl} target="_blank">
-          {baseurl}
+        <Link href={base_url} target="_blank">
+          {base_url}
         </Link>
         .
       </Text>
@@ -32,7 +32,8 @@ export default function Welcome(props: Props) {
 
 //
 
-export type Props = LayoutProps & {
+export type Props = {
+  base_url: string;
   family_name: string;
   given_name: string;
 };

--- a/packages/email/src/_layout.tsx
+++ b/packages/email/src/_layout.tsx
@@ -5,10 +5,6 @@ import { Html, ProConnectLogo, Section, Text } from "./components/index.js";
 
 //
 
-export interface LayoutProps {
-  baseurl: string;
-}
-
 export function VSpacing({ height }: { height: number }) {
   return (
     <Section style={`font-size:${height}px; line-height:${height}px;`}>
@@ -16,7 +12,7 @@ export function VSpacing({ height }: { height: number }) {
     </Section>
   );
 }
-export function Layout({ children }: PropsWithChildren<LayoutProps>) {
+export function Layout({ children }: PropsWithChildren) {
   return (
     <Html>
       <Section

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -461,7 +461,7 @@ export const greetForJoiningOrganization = async ({
     to: [email],
     subject: "Votre compte ProConnect a bien été créé",
     html: Welcome({
-      baseurl: HOST,
+      base_url: HOST,
       family_name: family_name ?? "",
       given_name: given_name ?? "",
     }).toString(),

--- a/src/managers/organization/official-contact-email-verification.ts
+++ b/src/managers/organization/official-contact-email-verification.ts
@@ -6,7 +6,6 @@ import type {
   UserOrganizationLink,
 } from "@proconnect-gouv/proconnect.identite/types";
 import { isEmpty } from "lodash-es";
-import { HOST } from "../../config/env";
 import {
   ApiAnnuaireContactEmailMismatchError,
   ApiAnnuaireError,
@@ -148,7 +147,6 @@ export const sendOfficialContactEmailVerificationEmail = async ({
     to: [contactEmail],
     subject: `[ProConnect] Authentifier un email sur ProConnect`,
     html: OfficialContactEmailVerification({
-      baseurl: HOST,
       given_name: given_name ?? "",
       family_name: family_name ?? "",
       email,

--- a/src/managers/user.ts
+++ b/src/managers/user.ts
@@ -30,7 +30,6 @@ import { chain, isEmpty, uniq } from "lodash-es";
 import { AssertionError } from "node:assert";
 import {
   FRANCECONNECT_VERIFICATION_MAX_AGE_IN_MINUTES,
-  HOST,
   MAGIC_LINK_TOKEN_EXPIRATION_DURATION_IN_MINUTES,
   MAX_DURATION_BETWEEN_TWO_EMAIL_ADDRESS_VERIFICATION_IN_MINUTES,
   RESET_PASSWORD_TOKEN_EXPIRATION_DURATION_IN_MINUTES,
@@ -211,7 +210,6 @@ export const sendEmailAddressVerificationEmail = async ({
     to: [user.email],
     subject: "Vérification de votre adresse email",
     html: VerifyEmail({
-      baseurl: HOST,
       token: verify_email_token,
     }).toString(),
     tag: "verify-email",
@@ -227,7 +225,6 @@ export const sendDeleteUserEmail = async ({ user_id }: { user_id: number }) => {
     to: [email],
     subject: "Suppression de compte",
     html: DeleteAccount({
-      baseurl: HOST,
       family_name: family_name ?? "",
       given_name: given_name ?? "",
       support_email: "support+identite@proconnect.gouv.fr",
@@ -248,7 +245,6 @@ export const sendDeleteFreeTOTPApplicationEmail = async ({
     subject:
       "Suppression d'une application d'authentification à double facteur",
     html: DeleteFreeTotpMail({
-      baseurl: HOST,
       family_name: family_name ?? "",
       given_name: given_name ?? "",
       support_email: "support+identite@proconnect.gouv.fr",
@@ -264,7 +260,6 @@ export const sendDisable2faMail = async ({ user_id }: { user_id: number }) => {
     to: [email],
     subject: "Désactivation de la validation avec la double authentification",
     html: Delete2faProtection({
-      baseurl: HOST,
       family_name: family_name ?? "",
       given_name: given_name ?? "",
     }).toString(),
@@ -283,7 +278,6 @@ export const sendDeleteAccessKeyMail = async ({
     to: [email],
     subject: "Alerte de sécurité",
     html: DeleteAccessKey({
-      baseurl: HOST,
       family_name: family_name ?? "",
       given_name: given_name ?? "",
       support_email: "support+identite@proconnect.gouv.fr",
@@ -303,7 +297,6 @@ export const sendAddFreeTOTPEmail = async ({
     to: [email],
     subject: "Double authentification activée",
     html: Add2fa({
-      baseurl: HOST,
       email,
       family_name: family_name ?? "",
       given_name: given_name ?? "",
@@ -323,7 +316,6 @@ export const sendActivateAccessKeyMail = async ({
     to: [email],
     subject: "Alerte de sécurité",
     html: AddAccessKey({
-      baseurl: HOST,
       family_name: family_name ?? "",
       given_name: given_name ?? "",
       support_email: "support+identite@proconnect.gouv.fr",
@@ -375,7 +367,6 @@ export const sendUpdatePersonalInformationEmail = async ({
       to: [email],
       subject: "Mise à jour de vos données personnelles",
       html: UpdatePersonalDataMail({
-        baseurl: HOST,
         family_name,
         given_name,
         updatedFields: updatedFields,
@@ -454,7 +445,6 @@ export const sendSendMagicLinkEmail = async (
     to: [user.email],
     subject: "Lien de connexion à ProConnect",
     html: MagicLink({
-      baseurl: host,
       magic_link: `${host}/users/sign-in-with-magic-link?magic_link_token=${magicLinkToken}`,
     }).toString(),
     tag: "magic-link",
@@ -514,7 +504,6 @@ export const sendResetPasswordEmail = async (
     to: [user.email],
     subject: "Instructions pour la réinitialisation du mot de passe",
     html: ResetPassword({
-      baseurl: host,
       reset_password_link: `${host}/users/change-password?reset_password_token=${resetPasswordToken}`,
     }).toString(),
     tag: "reset-password",


### PR DESCRIPTION
**Problem**
The `baseurl` parameter was required for every email template, even though it was no longer used.

**Proposal**
Remove the unused `baseurl` parameter from the email template API.