### PR TITLE
✨ personal-information: allow disconnecting FranceConnect identity

### DIFF
--- a/cypress/e2e/disconnect_franceconnect_account/fixtures.sql
+++ b/cypress/e2e/disconnect_franceconnect_account/fixtures.sql
@@ -1,0 +1,78 @@
+INSERT INTO
+  users (
+    id,
+    email,
+    email_verified,
+    email_verified_at,
+    encrypted_password,
+    created_at,
+    updated_at,
+    given_name,
+    family_name,
+    phone_number,
+    job
+  )
+VALUES
+  (
+    1,
+    'jean.valjean@republic.fr',
+    true,
+    CURRENT_TIMESTAMP,
+    '$2a$10$kzY3LINL6..50Fy9shWCcuNlRfYq0ft5lS.KCcJ5PzrhlWfKK4NIO',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    'Jean',
+    'Valjean',
+    '0600000001',
+    'Forçat'
+  );
+
+INSERT INTO
+  organizations (id, siret, created_at, updated_at)
+VALUES
+  (
+    1,
+    '21340126800130',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+  );
+
+INSERT INTO
+  users_organizations (
+    user_id,
+    organization_id,
+    is_external,
+    verification_type,
+    has_been_greeted
+  )
+VALUES
+  (1, 1, false, 'domain', true);
+
+INSERT INTO
+  franceconnect_userinfo (
+    user_id,
+    birthdate,
+    birthplace,
+    family_name,
+    gender,
+    given_name,
+    preferred_username,
+    sub,
+    created_at,
+    updated_at,
+    birthcountry
+  )
+VALUES
+  (
+    1,
+    '1769-06-24 00:00:00+00',
+    '75107',
+    'Valjean',
+    'male',
+    'Jean',
+    '',
+    '🎭 FranceConnect Sub',
+    '2026-02-20 14:06:52.812827+00',
+    '2026-02-20 14:06:52.812+00',
+    '99100'
+  );

--- a/cypress/e2e/disconnect_franceconnect_account/index.cy.ts
+++ b/cypress/e2e/disconnect_franceconnect_account/index.cy.ts
@@ -1,0 +1,44 @@
+describe("Disconnect FranceConnect account", () => {
+  before(cy.seed);
+
+  it("should disconnect FranceConnect and restore editable name fields", function () {
+    cy.visit("/personal-information");
+
+    cy.login("jean.valjean@republic.fr");
+
+    cy.visit("/personal-information");
+
+    cy.title().should("include", "Informations personnelles -");
+
+    cy.contains("À choisir parmi la liste de vos prénoms issus de");
+    cy.get('select[name="given_name"]').should("exist");
+    cy.get('select[name="family_name"]').should("exist");
+
+    cy.contains("Identité FranceConnect");
+    cy.contains(
+      "Vous avez utilisé votre identité FranceConnect pour pré-remplir vos informations personnelles.",
+    );
+    cy.contains("Dernière connexion FranceConnect");
+    cy.contains("vendredi 20 février 2026");
+    cy.contains("Mettre à jour votre identité FranceConnect");
+    cy.contains(
+      "Supprimer le lien entre FranceConnect et votre compte ProConnect",
+    );
+
+    cy.contains("Délier les comptes").click();
+
+    cy.title().should("include", "Informations personnelles -");
+    cy.contains("Vous êtes maintenant déconnecté de FranceConnect.");
+
+    cy.get('select[name="given_name"]').should("not.exist");
+    cy.get('select[name="family_name"]').should("not.exist");
+    cy.seeInField("Prénom", "Jean");
+    cy.seeInField("Nom", "Valjean");
+
+    cy.contains(
+      "Vous pouvez utiliser votre identité FranceConnect pour pré-remplir vos informations personnelles.",
+    );
+    cy.contains("Délier les comptes").should("not.exist");
+    cy.contains("Dernière connexion FranceConnect").should("not.exist");
+  });
+});

--- a/cypress/e2e/disconnect_franceconnect_account/index.cy.ts
+++ b/cypress/e2e/disconnect_franceconnect_account/index.cy.ts
@@ -1,0 +1,27 @@
+describe("Disconnect FranceConnect account", () => {
+  before(cy.seed);
+
+  it("should disconnect FranceConnect and restore editable name fields", function () {
+    cy.visit("/personal-information");
+
+    cy.login("jean.valjean@republic.fr");
+
+    cy.visit("/personal-information");
+
+    cy.title().should("include", "Informations personnelles -");
+
+    cy.contains("À choisir parmi la liste de vos prénoms issus de");
+    cy.get('select[name="given_name"]').should("exist");
+    cy.get('select[name="family_name"]').should("exist");
+
+    cy.contains("Se déconnecter de FranceConnect").click();
+
+    cy.title().should("include", "Informations personnelles -");
+    cy.contains("Vous êtes maintenant déconnecté de FranceConnect.");
+
+    cy.get('select[name="given_name"]').should("not.exist");
+    cy.get('select[name="family_name"]').should("not.exist");
+    cy.seeInField("Prénom", "Jean");
+    cy.seeInField("Nom", "Valjean");
+  });
+});

--- a/packages/identite/src/connectors/index.ts
+++ b/packages/identite/src/connectors/index.ts
@@ -11,6 +11,7 @@ import { findByIdFactory as findOrganizationByIdFactory } from "../repositories/
 import { findByUserIdFactory } from "../repositories/organization/find-by-user-id.js";
 import { getUsersByOrganizationFactory } from "../repositories/organization/get-users-by-organization.js";
 import { createUserFactory } from "../repositories/user/create.js";
+import { deleteFranceConnectUserInfoFactory } from "../repositories/user/delete-franceconnect-userinfo.js";
 import { findByEmailFactory } from "../repositories/user/find-by-email.js";
 import { findByIdFactory as findUserByIdFactory } from "../repositories/user/find-by-id.js";
 import { getByIdFactory } from "../repositories/user/get-by-id.js";
@@ -56,6 +57,7 @@ export function createContext({
       },
       users: {
         create: createUserFactory({ pg }),
+        deleteFranceConnectUserInfo: deleteFranceConnectUserInfoFactory({ pg }),
         findByEmail: findByEmailFactory({ pg }),
         findById: findUserByIdFactory({ pg }),
         getById: getByIdFactory({ pg }),

--- a/packages/identite/src/connectors/index.ts
+++ b/packages/identite/src/connectors/index.ts
@@ -33,6 +33,7 @@ import { getUsersByOrganizationFactory } from "../repositories/organization/get-
 import { linkUserToOrganizationFactory } from "../repositories/organization/link-user-to-organization.js";
 import { upsertFactory } from "../repositories/organization/upsert.js";
 import { createUserFactory } from "../repositories/user/create.js";
+import { deleteFranceConnectUserInfoFactory } from "../repositories/user/delete-franceconnect-userinfo.js";
 import { deleteUserFactory } from "../repositories/user/delete.js";
 import { findByEmailFactory } from "../repositories/user/find-by-email.js";
 import { findByIdFactory as findUserByIdFactory } from "../repositories/user/find-by-id.js";
@@ -113,6 +114,7 @@ export function createContext({
       users: {
         create: createUserFactory({ pg }),
         delete: deleteUserFactory({ pg }),
+        deleteFranceConnectUserInfo: deleteFranceConnectUserInfoFactory({ pg }),
         findByEmail: findByEmailFactory({ pg }),
         findById: findUserByIdFactory({ pg }),
         findByMagicLinkToken: findByMagicLinkTokenFactory({ pg }),

--- a/packages/identite/src/repositories/user/delete-franceconnect-userinfo.test.ts
+++ b/packages/identite/src/repositories/user/delete-franceconnect-userinfo.test.ts
@@ -1,0 +1,47 @@
+//
+
+import { emptyDatabase, migrate, pg } from "#testing";
+import assert from "node:assert/strict";
+import { before, beforeEach, describe, it } from "node:test";
+import { deleteFranceConnectUserInfoFactory } from "./delete-franceconnect-userinfo.js";
+import { getFranceConnectUserInfoFactory } from "./get-franceconnect-user-info.js";
+
+//
+
+const deleteFranceConnectUserInfo = deleteFranceConnectUserInfoFactory({
+  pg: pg as any,
+});
+const getFranceConnectUserInfo = getFranceConnectUserInfoFactory({
+  pg: pg as any,
+});
+
+describe("deleteFranceConnectUserInfo", () => {
+  before(migrate);
+  beforeEach(emptyDatabase);
+
+  it("should delete franceconnect user info", async () => {
+    await pg.sql`
+      INSERT INTO users
+        (id, email, created_at, updated_at, given_name, family_name, phone_number, job)
+      VALUES
+        (1, 'lion.eljonson@darkangels.world', '4444-04-04', '4444-04-04', 'lion', 'el''jonson', 'i', 'primarque')
+      ;
+    `;
+    await pg.sql`
+      INSERT INTO franceconnect_userinfo
+        (user_id, birthdate, birthplace, family_name, gender, given_name, preferred_username, sub, created_at, updated_at)
+        VALUES
+        (1, '8888-08-08', 'Caliban', 'El''Jonson', 'male', 'Li', 'Li', 'abcdefghijklmnopqrstuvwxyz', '4444-04-04', '4444-04-04')
+      ;
+    `;
+
+    await deleteFranceConnectUserInfo(1);
+
+    const user = await getFranceConnectUserInfo(1);
+    assert.equal(user, undefined);
+  });
+
+  it("should not throw when deleting a user_id with no row", async () => {
+    await assert.doesNotReject(() => deleteFranceConnectUserInfo(42));
+  });
+});

--- a/packages/identite/src/repositories/user/delete-franceconnect-userinfo.ts
+++ b/packages/identite/src/repositories/user/delete-franceconnect-userinfo.ts
@@ -1,0 +1,21 @@
+//
+
+import type { DatabaseContext } from "#src/types";
+
+//
+
+export function deleteFranceConnectUserInfoFactory({ pg }: DatabaseContext) {
+  return async function deleteFranceConnectUserInfo(user_id: number) {
+    return pg.query(
+      `
+      DELETE FROM franceconnect_userinfo
+      WHERE user_id = $1
+      `,
+      [user_id],
+    );
+  };
+}
+
+export type DeleteFranceConnectUserInfoHandler = ReturnType<
+  typeof deleteFranceConnectUserInfoFactory
+>;

--- a/src/config/notification-messages.ts
+++ b/src/config/notification-messages.ts
@@ -120,6 +120,10 @@ Si vous avez oublié votre mot de passe cliquez sur « Mot de passe oublié ?�
     type: "success",
     description: "Nous avons bien récupéré vos données via FranceConnect.",
   },
+  personal_information_franceconnect_disconnected_success: {
+    type: "success",
+    description: "Vous êtes maintenant déconnecté de FranceConnect.",
+  },
   official_contact_email_verification_not_needed: {
     type: "error",
     description:

--- a/src/controllers/main.ts
+++ b/src/controllers/main.ts
@@ -9,6 +9,7 @@ import {
 } from "../managers/session/authenticated";
 import { isTotpConfiguredForUser } from "../managers/totp";
 import {
+  disconnectFranceConnectIdentity,
   getFamilyNameOptionsFromFranceConnectIdentity,
   getGivenNameOptionsFromFranceConnectIdentity,
   hasFranceConnectIdentity,
@@ -128,6 +129,24 @@ export const postPersonalInformationsController = async (
       );
     }
 
+    next(error);
+  }
+};
+
+export const postDisconnectFranceConnectController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const { id: userId } = getUserFromAuthenticatedSession(req);
+
+    await disconnectFranceConnectIdentity(userId);
+
+    return res.redirect(
+      "/personal-information?notification=personal_information_franceconnect_disconnected_success",
+    );
+  } catch (error) {
     next(error);
   }
 };

--- a/src/controllers/main.ts
+++ b/src/controllers/main.ts
@@ -10,10 +10,11 @@ import {
 } from "../managers/session/authenticated";
 import { isTotpConfiguredForUser } from "../managers/totp";
 import {
+  disconnectFranceConnectIdentity,
   getFamilyNameOptionsFromFranceConnectIdentity,
   getGivenNameOptionsFromFranceConnectIdentity,
-  hasFranceConnectIdentity,
   hasValidFranceConnectIdentity,
+  lastFranceConnectIdentityUpdate,
   sendUpdatePersonalInformationEmail,
 } from "../managers/user";
 import { getUserAuthenticators } from "../managers/webauthn";
@@ -60,7 +61,7 @@ export const getPersonalInformationsController = async (
       notifications: await getNotificationsFromRequest(req),
       pageTitle: "Informations personnelles",
       phone_number: user.phone_number,
-      hasFranceConnectIdentity: await hasFranceConnectIdentity(user.id),
+      franceConnect_last_update: await lastFranceConnectIdentityUpdate(user.id),
       givenNameOptions,
       familyNameOptions,
     });
@@ -76,7 +77,7 @@ export const postPersonalInformationsController = async (
 ) => {
   try {
     const { id: userId } = getUserFromAuthenticatedSession(req);
-    const hasFCIdentity = await hasFranceConnectIdentity(userId);
+    const hasFCIdentity = await lastFranceConnectIdentityUpdate(userId);
 
     let givenNameOptions: string[] = [];
     let familyNameOptions: string[] = [];
@@ -130,6 +131,24 @@ export const postPersonalInformationsController = async (
       );
     }
 
+    next(error);
+  }
+};
+
+export const postDisconnectFranceConnectController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  try {
+    const { id: userId } = getUserFromAuthenticatedSession(req);
+
+    await disconnectFranceConnectIdentity(userId);
+
+    return res.redirect(
+      "/personal-information?notification=personal_information_franceconnect_disconnected_success",
+    );
+  } catch (error) {
     next(error);
   }
 };

--- a/src/controllers/user/update-personal-informations.ts
+++ b/src/controllers/user/update-personal-informations.ts
@@ -6,7 +6,7 @@ import {
   getUserFromAuthenticatedSession,
   updateUserInAuthenticatedSession,
 } from "../../managers/session/authenticated";
-import { hasFranceConnectIdentity } from "../../managers/user";
+import { lastFranceConnectIdentityUpdate } from "../../managers/user";
 import { csrfToken } from "../../middlewares/csrf-protection";
 import { nameSchema } from "../../services/custom-zod-schemas";
 import getNotificationsFromRequest from "../../services/get-notifications-from-request";
@@ -37,7 +37,7 @@ export const getPersonalInformationsController = async (
       notifications: await getNotificationsFromRequest(req),
       pageTitle: "Renseigner votre identité",
       phone_number,
-      hasFranceConnectIdentity: await hasFranceConnectIdentity(userId),
+      hasFranceConnectIdentity: await lastFranceConnectIdentityUpdate(userId),
     });
   } catch (error) {
     next(error);
@@ -51,7 +51,7 @@ export const postPersonalInformationsController = async (
 ) => {
   try {
     const { id: userId } = getUserFromAuthenticatedSession(req);
-    const hasFCIdentity = await hasFranceConnectIdentity(userId);
+    const hasFCIdentity = await lastFranceConnectIdentityUpdate(userId);
 
     let updatedUser: User;
 

--- a/src/managers/user.ts
+++ b/src/managers/user.ts
@@ -51,6 +51,7 @@ import { hasPasswordBeenPwned } from "../connectors/pwnedpasswords";
 import { findEmailInDeliverabilityWhiteList } from "../repositories/email-deliverability-whitelist";
 import {
   create,
+  deleteFranceConnectUserInfo,
   findByEmail,
   findByMagicLinkToken,
   findByResetPasswordToken,
@@ -587,6 +588,10 @@ export async function hasValidFranceConnectIdentity(userId: number) {
 
 export async function hasFranceConnectIdentity(userId: number) {
   return !isEmpty(await getFranceConnectUserInfo(userId));
+}
+
+export async function disconnectFranceConnectIdentity(userId: number) {
+  return deleteFranceConnectUserInfo(userId);
 }
 
 export async function needsFranceConnectIdentityRenewal(userId: number) {

--- a/src/managers/user.ts
+++ b/src/managers/user.ts
@@ -54,6 +54,7 @@ import { isWebauthnConfiguredForUser } from "./webauthn";
 
 const {
   create,
+  deleteFranceConnectUserInfo,
   findByEmail,
   findByMagicLinkToken,
   findByResetPasswordToken,
@@ -589,8 +590,14 @@ export async function hasValidFranceConnectIdentity(userId: number) {
   );
 }
 
-export async function hasFranceConnectIdentity(userId: number) {
-  return !isEmpty(await getFranceConnectUserInfo(userId));
+export async function lastFranceConnectIdentityUpdate(userId: number) {
+  const userFranceConnect = await getFranceConnectUserInfo(userId);
+  if (isEmpty(userFranceConnect)) return false;
+  return userFranceConnect.updated_at;
+}
+
+export async function disconnectFranceConnectIdentity(userId: number) {
+  return deleteFranceConnectUserInfo(userId);
 }
 
 export async function needsFranceConnectIdentityRenewal(userId: number) {

--- a/src/middlewares/navigation-guards.ts
+++ b/src/middlewares/navigation-guards.ts
@@ -45,8 +45,8 @@ import {
   getPartialUserFromUnauthenticatedSession,
 } from "../managers/session/unauthenticated";
 import {
-  hasFranceConnectIdentity,
   hasValidFranceConnectIdentity,
+  lastFranceConnectIdentityUpdate,
   needsEmailVerificationRenewal,
   needsFranceConnectIdentityRenewal,
 } from "../managers/user";
@@ -574,7 +574,7 @@ const userHasValidFranceConnectIdentityGuard = async <
   const { id: user_id } = getUserFromAuthenticatedSession(req);
 
   if (
-    (await hasFranceConnectIdentity(user_id)) &&
+    (await lastFranceConnectIdentityUpdate(user_id)) &&
     (await needsFranceConnectIdentityRenewal(user_id))
   ) {
     return redirect("/users/franceconnect");

--- a/src/repositories/user.ts
+++ b/src/repositories/user.ts
@@ -7,6 +7,7 @@ import { getDatabaseConnection } from "../connectors/postgres";
 
 export const {
   create,
+  deleteFranceConnectUserInfo,
   findByEmail,
   findById,
   getById,

--- a/src/routers/main.ts
+++ b/src/routers/main.ts
@@ -20,6 +20,7 @@ import {
   getManageOrganizationsController,
   getPersonalInformationsController,
   getPolitiqueDeConfidentialiteController,
+  postDisconnectFranceConnectController,
   postPersonalInformationsController,
 } from "../controllers/main";
 import {
@@ -244,6 +245,17 @@ export const mainRouter = (app: Express) => {
     userCanAccessAppGuardMiddleware,
     csrfProtectionMiddleware,
     postPersonalInformationsController,
+  );
+
+  mainRouter.post(
+    "/personal-information/franceconnect/disconnect",
+    nocache(),
+    urlencoded({ extended: false }),
+    ejsLayoutMiddlewareFactory(app, true),
+    rateLimiterMiddleware,
+    userCanAccessAppGuardMiddleware,
+    csrfProtectionMiddleware,
+    postDisconnectFranceConnectController,
   );
 
   mainRouter.get(

--- a/src/routers/main.ts
+++ b/src/routers/main.ts
@@ -13,6 +13,7 @@ import {
   getManageOrganizationsController,
   getPersonalInformationsController,
   getPolitiqueDeConfidentialiteController,
+  postDisconnectFranceConnectController,
   postPersonalInformationsController,
 } from "../controllers/main";
 import {
@@ -160,6 +161,17 @@ export const mainRouter = (app: Express) => {
     userCanAccessAppGuardMiddleware,
     csrfProtectionMiddleware,
     postPersonalInformationsController,
+  );
+
+  mainRouter.post(
+    "/personal-information/franceconnect/disconnect",
+    nocache(),
+    urlencoded({ extended: false }),
+    ejsLayoutMiddlewareFactory(app, true),
+    rateLimiterMiddleware,
+    userCanAccessAppGuardMiddleware,
+    csrfProtectionMiddleware,
+    postDisconnectFranceConnectController,
   );
 
   mainRouter.get(

--- a/src/views/personal-information.ejs
+++ b/src/views/personal-information.ejs
@@ -1,6 +1,6 @@
 <div class="dashboard-container">
     <%- include('partials/sidemenu.ejs', {activeLink: 'personal-information'}) %>
-    <div class="dashboard-content fr-col-12 fr-col-lg-10 fr-col-xl-9 fr-col-offset-lg-1">
+    <div class="dashboard-content fr-mb-12w fr-col-12 fr-col-lg-10 fr-col-xl-9 fr-col-offset-lg-1">
         <%- include('partials/notifications.ejs', {notifications: notifications}) %>
         <h1 class="fr-h2">
             Vos informations personnelles
@@ -10,7 +10,7 @@
 
             <p aria-hidden="true" class="fr-hint-text">Les champs notés * sont obligatoires.</p>
 
-            <% if (locals.hasFranceConnectIdentity) { %>
+            <% if (locals.franceConnect_last_update) { %>
             <div class="fr-select-group">
                 <label class="fr-label" for="given_name">
                     Prénom<span aria-hidden="true"> *</span>
@@ -46,7 +46,7 @@
             </div>
             <% } %>
 
-            <% if (locals.hasFranceConnectIdentity) { %>
+            <% if (locals.franceConnect_last_update) { %>
             <div class="fr-select-group">
                 <label class="fr-label" for="family_name">
                     Nom<span aria-hidden="true"> *</span>
@@ -120,7 +120,21 @@
             </button>
         </form>
 
+        <h1 class="fr-h3 fr-mt-4w">Identité FranceConnect</h1>
+
+        <% if (locals.franceConnect_last_update) { %>
+
+        <p>
+          Vous avez utilisé votre identité FranceConnect pour pré-remplir vos informations personnelles. <br/>
+          <em>Dernière connexion FranceConnect :
+          le <%= locals.franceConnect_last_update.toLocaleString("fr-FR", { weekday: "long", year: "numeric", month: "long", day: "numeric", timeZone: "UTC" }); %>
+          à <%= locals.franceConnect_last_update.toLocaleTimeString("fr-FR"); %></em>
+        </p>
+
+        <h2 class="fr-h6">Mettre à jour votre identité FranceConnect</h2>
+
         <p class="fr-mt-4w">Si votre état civil a été modifié, vous pouvez mettre à jour vos informations en récupérant vos données via FranceConnect.</p>
+
 
         <form action="/users/personal-information/franceconnect/login" method="post">
           <input type="hidden" name="_csrf" value="<%= csrfToken; %>" />
@@ -144,5 +158,44 @@
             </p>
           </div>
         </form>
+
+        <h2 class="fr-h6">Supprimer le lien entre FranceConnect et votre compte ProConnect</h2>
+
+        <form action="/personal-information/franceconnect/disconnect" method="post">
+          <input type="hidden" name="_csrf" value="<%= csrfToken; %>" />
+          <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-link-unlink" type="submit">
+            Délier les comptes
+          </button>
+        </form>
+
+        <% } else { %>
+
+        <p>
+          Vous pouvez utiliser votre identité FranceConnect pour pré-remplir vos informations personnelles.
+        </p>
+
+        <form action="/users/personal-information/franceconnect/login" method="post">
+          <input type="hidden" name="_csrf" value="<%= csrfToken; %>" />
+
+          <div class="fr-connect-group">
+            <p class="text-muted">
+              FranceConnect est la solution proposée par l’État pour sécuriser et simplifier la connexion à vos services en ligne.
+            </p>
+
+            <button class="fr-connect">
+              <span class="fr-connect__login">S’identifier avec</span>
+              <span class="fr-connect__brand">FranceConnect</span>
+            </button>
+            <p>
+              <a
+                href="https://franceconnect.gouv.fr/"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Qu’est-ce que FranceConnect ?</a
+              >
+            </p>
+          </div>
+        </form>
+        <% } %>
     </div>
 </div>

--- a/src/views/personal-information.ejs
+++ b/src/views/personal-information.ejs
@@ -144,5 +144,14 @@
             </p>
           </div>
         </form>
+
+        <% if (locals.hasFranceConnectIdentity) { %>
+        <form action="/personal-information/franceconnect/disconnect" method="post">
+          <input type="hidden" name="_csrf" value="<%= csrfToken; %>" />
+          <button class="fr-btn fr-btn--secondary" type="submit">
+            Se déconnecter de FranceConnect
+          </button>
+        </form>
+        <% } %>
     </div>
 </div>


### PR DESCRIPTION
**Problem**

A user whose FranceConnect data is stale or wrong has no way to unlink it — given_name/family_name stay locked to FranceConnect-sourced options forever.

**Proposal**

Add a "Se déconnecter de FranceConnect" action on /personal-information that deletes the franceconnect_userinfo row for the user. Every FranceConnect-aware check (identity guards, name-option lookups) reads that table live per-request, so the delete alone restores free-text editable fields everywhere.

---

<img width="934" height="360" alt="image" src="https://github.com/user-attachments/assets/45970c6e-5704-4c7e-bb08-562440b00777" />
