### PR TITLE
✨ feat: add dedicated OTP email template

### DIFF
--- a/.changeset/little-hats-do.md
+++ b/.changeset/little-hats-do.md
@@ -1,0 +1,5 @@
+---
+"@proconnect-gouv/proconnect.email": patch
+---
+
+ajout d'un template "OTP e-mail"

--- a/packages/email/src/OtpEmail.stories.tsx
+++ b/packages/email/src/OtpEmail.stories.tsx
@@ -1,0 +1,15 @@
+//
+
+import type { ComponentAnnotations, Renderer } from "@storybook/csf";
+import OtpEmail, { type Props } from "./OtpEmail.js";
+
+//
+
+export default {
+  title: "OTP Email",
+  render: OtpEmail,
+  args: {
+    token: "01928374",
+    validityDuration: "1 heure",
+  } as Props,
+} as ComponentAnnotations<Renderer, Props>;

--- a/packages/email/src/OtpEmail.test.tsx
+++ b/packages/email/src/OtpEmail.test.tsx
@@ -1,0 +1,20 @@
+//
+
+import { describe, it } from "node:test";
+import { format } from "prettier";
+import OtpEmail, { type Props } from "./OtpEmail.js";
+import storyConfig from "./OtpEmail.stories.js";
+import "./test-utils.js";
+
+//
+
+describe("OtpEmail", () => {
+  it("should render", async (t) => {
+    const props = storyConfig.args as Props;
+    const rendered = (<OtpEmail {...props} />).toString();
+    const formatted = await format(rendered, { parser: "html" });
+    t.assert.snapshot(formatted);
+  });
+});
+
+//

--- a/packages/email/src/OtpEmail.test.tsx.snapshot
+++ b/packages/email/src/OtpEmail.test.tsx.snapshot
@@ -1,0 +1,275 @@
+exports[`OtpEmail > should render 1`] = `
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body style="background-color: #fafafa; padding-top: 32px">
+    <table
+      width="100%"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      bgcolor="#FAFAFA"
+    >
+      <tr>
+        <td align="center" valign="top">
+          <table
+            align="center"
+            width="800"
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+            style="max-width: 800px; width: 100%"
+          >
+            <tbody>
+              <tr>
+                <td>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="font-size: 64px; line-height: 64px"
+                  >
+                    <tbody>
+                      <tr>
+                        <td> </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style=""
+                  >
+                    <tbody>
+                      <tr>
+                        <td align="center">
+                          <img
+                            src="https://identite.proconnect.gouv.fr/dist/mail-proconnect.png"
+                            alt="ProConnect"
+                            height="73"
+                            width="193"
+                          />
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="font-size: 64px; line-height: 64px"
+                  >
+                    <tbody>
+                      <tr>
+                        <td> </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    bgcolor="#FFFFFF"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="box-shadow: 0px 2px 6px 0px rgba(0, 0, 18, 0.16)"
+                  >
+                    <tbody>
+                      <tr>
+                        <td>
+                          <table
+                            align="center"
+                            width="100%"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 64px; line-height: 64px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td> </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table
+                            align="center"
+                            width="600"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="max-width: 600px; width: 100%; padding: 24px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="
+                                      color: #000;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-weight: 400;
+                                      line-height: 24px;
+                                      margin: 0;
+                                    "
+                                  >
+                                    Bonjour,
+                                  </p>
+                                  <br />
+                                  <p
+                                    style="
+                                      color: #000;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-weight: 400;
+                                      line-height: 24px;
+                                      margin: 0;
+                                    "
+                                  >
+                                    Voici votre code de connexion à usage
+                                    unique.<br />Merci de copier-coller ou de
+                                    renseigner ce code dans l’interface de
+                                    connexion ProConnect.<br /><em
+                                      style="
+                                        color: #000091;
+                                        font-family:
+                                          &quot;Source Sans Pro&quot;, Verdana,
+                                          Geneva, Arial, sans-serif;
+                                        font-size: 16px;
+                                        font-style: normal;
+                                        font-weight: bold;
+                                        line-height: 24px;
+                                        margin: 0;
+                                      "
+                                      >Ce code est valable 1 heure.</em
+                                    >
+                                  </p>
+                                  <br /><br /><span
+                                    style="
+                                      background-color: #e8edff;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-style: normal;
+                                      line-height: 24px;
+                                      margin: 0;
+                                      padding: 8px 16px;
+                                    "
+                                    aria-label="Code de connexion à usage unique"
+                                    ><em
+                                      style="
+                                        color: #000091;
+                                        font-family:
+                                          &quot;Source Sans Pro&quot;, Verdana,
+                                          Geneva, Arial, sans-serif;
+                                        font-size: 16px;
+                                        font-style: normal;
+                                        font-weight: bold;
+                                        line-height: 24px;
+                                        margin: 0;
+                                        letter-spacing: 0.2em;
+                                      "
+                                      >01928374</em
+                                    ></span
+                                  ><br /><br />
+                                  <p
+                                    style="
+                                      color: #000;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-weight: 400;
+                                      line-height: 24px;
+                                      margin: 0;
+                                      margin-top: 16px;
+                                    "
+                                  >
+                                    Cordialement,<br />L'équipe ProConnect
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table
+                            align="center"
+                            width="100%"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 64px; line-height: 64px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td> </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="font-size: 64px; line-height: 64px"
+                  >
+                    <tbody>
+                      <tr>
+                        <td> </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <table
+            align="center"
+            width="100%"
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+            style="font-size: 64px; line-height: 64px"
+          >
+            <tbody>
+              <tr>
+                <td> </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+
+`;

--- a/packages/email/src/OtpEmail.tsx
+++ b/packages/email/src/OtpEmail.tsx
@@ -1,0 +1,35 @@
+//
+
+import { Layout } from "./_layout.js";
+import { Badge, Em, Text } from "./components/index.js";
+
+//
+
+export default function OtpEmail(props: Props) {
+  const { token, validityDuration } = props;
+  return (
+    <Layout>
+      <Text>Bonjour,</Text>
+      <br />
+      <Text>
+        Voici votre code de connexion à usage unique.
+        <br />
+        Merci de copier-coller ou de renseigner ce code dans l’interface de
+        connexion ProConnect.
+        <br />
+        <Em>Ce code est valable {validityDuration}.</Em>
+      </Text>
+      <br />
+      <br />
+      <Badge aria-label="Code de connexion à usage unique">
+        <Em style={{ letterSpacing: "0.2em" }}>{token}</Em>
+      </Badge>
+      <br />
+      <br />
+    </Layout>
+  );
+}
+
+//
+
+export type Props = { token: string; validityDuration: string };

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -8,6 +8,7 @@ export { default as DeleteAccount } from "./DeleteAccount.js";
 export { default as DeleteFreeTotpMail } from "./DeleteFreeTotpMail.js";
 export { default as MagicLink } from "./MagicLink.js";
 export { default as OfficialContactEmailVerification } from "./OfficialContactEmailVerification.js";
+export { default as OtpEmail } from "./OtpEmail.js";
 export { default as ResetPassword } from "./ResetPassword.js";
 export { default as UpdatePersonalDataMail } from "./UpdatePersonalDataMail.js";
 export { default as VerifyEmail } from "./VerifyEmail.js";


### PR DESCRIPTION
**Problem**
The OTP email currently reuses the email verification template, making its content inaccurate and potentially confusing.

**Proposal**
Create a dedicated email template for OTP messages.

<img width="1860" height="1344" alt="image" src="https://github.com/user-attachments/assets/225ea2af-b5b1-4a13-90b1-0b2af35d762f" />


