### PR TITLE
✨ Add siret and cached_libelle to unable join organisation email

### DIFF
--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -504,7 +504,7 @@ export const createPendingModeration = async ({
 
   if (CRISP_WEBSITE_ID) {
     ticket_id = await startCripsConversation({
-      content: unableToAutoJoinOrganizationMd(),
+      content: unableToAutoJoinOrganizationMd({ siret, cached_libelle }),
       email,
       subject: `[ProConnect] Demande pour rejoindre ${cached_libelle || siret}`,
     });

--- a/src/views/mails/unable-to-auto-join-organization.ts
+++ b/src/views/mails/unable-to-auto-join-organization.ts
@@ -4,13 +4,19 @@ import { HOST } from "../../config/env";
 
 //
 
-export function unableToAutoJoinOrganizationMd() {
+export function unableToAutoJoinOrganizationMd({
+  siret,
+  cached_libelle,
+}: {
+  siret: string;
+  cached_libelle: string | null;
+}): string {
   return `
 ![ProConnect](${HOST}/dist/mail-proconnect.png)
 
 Bonjour,
 
-Nous vérifions votre lien à l’organisation, vous recevrez un email de confirmation dès que votre compte sera validé.
+Nous vérifions votre lien à l’organisation ${cached_libelle ? `${cached_libelle} (${siret})` : `(${siret})`}, vous recevrez un email de confirmation dès que votre compte sera validé.
 (délai moyen : 1 jour ouvré)
 
 Cordialement,


### PR DESCRIPTION
**Problem:** 
A lack of context for support staff when they receive replies to emails to join an organisation

**Fix:**
Include the SIRET number and the name of the organisation in the email so that support can more easily trace the user’s journey

**Question about this pr:** 
How to test this change? Snapshot? @rdubigny @BenoitSerrano @gdarquie 