### PR TITLE
✨ notify user by email when a moderation demand is cancelled

### DIFF
--- a/.changeset/tidy-mangos-attend.md
+++ b/.changeset/tidy-mangos-attend.md
@@ -1,0 +1,5 @@
+---
+"@proconnect-gouv/proconnect.email": minor
+---
+
+ajout d'un template "annulation de demande de rattachement"

--- a/cypress/e2e/join_and_moderation/index.cy.ts
+++ b/cypress/e2e/join_and_moderation/index.cy.ts
@@ -20,6 +20,27 @@ describe("join and moderation", () => {
       cy.contains("Demande en cours");
     });
 
+    it("can cancel the moderation demand and receives a confirmation email", function () {
+      cy.visit("/manage-organizations");
+
+      cy.login("lion.eljonson@darkangels.world");
+
+      cy.title().should("include", "Organisations -");
+      cy.contains("Annuler ma demande de rattachement").click();
+
+      cy.contains("Votre demande de rattachement a bien été annulée.");
+
+      cy.maildevGetMessageBySubject(
+        "Annulation de votre demande de rattachement",
+      ).then((email) => {
+        cy.maildevVisitMessageById(email.id);
+        cy.contains(
+          "Nous vous confirmons que votre demande de rattachement à l'organisation « Bnp paribas - Bnp paribas » a bien été annulée.",
+        );
+        cy.maildevDeleteMessageById(email.id);
+      });
+    });
+
     it("will be moderated when login to an SP", function () {
       cy.origin("http://localhost:4000", () => {
         cy.visit("/");

--- a/packages/email/src/CancelModeration.stories.tsx
+++ b/packages/email/src/CancelModeration.stories.tsx
@@ -1,0 +1,16 @@
+//
+
+import type { ComponentAnnotations, Renderer } from "@storybook/csf";
+import CancelModeration, { type Props } from "./CancelModeration.js";
+
+//
+
+export default {
+  title: "Cancel Moderation",
+  render: CancelModeration,
+  args: {
+    given_name: "Marie",
+    family_name: "Dupont",
+    libelle: "Ministère de la Culture",
+  },
+} as ComponentAnnotations<Renderer, Props>;

--- a/packages/email/src/CancelModeration.test.tsx
+++ b/packages/email/src/CancelModeration.test.tsx
@@ -1,0 +1,20 @@
+//
+
+import { describe, it } from "node:test";
+import { format } from "prettier";
+import CancelModeration, { type Props } from "./CancelModeration.js";
+import storyConfig from "./CancelModeration.stories.js";
+import "./test-utils.js";
+
+//
+
+describe("CancelModeration", () => {
+  it("should render", async (t) => {
+    const props = storyConfig.args as Props;
+    const rendered = (<CancelModeration {...props} />).toString();
+    const formatted = await format(rendered, { parser: "html" });
+    t.assert.snapshot(formatted);
+  });
+});
+
+//

--- a/packages/email/src/CancelModeration.test.tsx.snapshot
+++ b/packages/email/src/CancelModeration.test.tsx.snapshot
@@ -1,0 +1,240 @@
+exports[`CancelModeration > should render 1`] = `
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body style="background-color: #fafafa; padding-top: 32px">
+    <table
+      width="100%"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      bgcolor="#FAFAFA"
+    >
+      <tr>
+        <td align="center" valign="top">
+          <table
+            align="center"
+            width="800"
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+            style="max-width: 800px; width: 100%"
+          >
+            <tbody>
+              <tr>
+                <td>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="font-size: 64px; line-height: 64px"
+                  >
+                    <tbody>
+                      <tr>
+                        <td> </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style=""
+                  >
+                    <tbody>
+                      <tr>
+                        <td align="center">
+                          <img
+                            src="https://identite.proconnect.gouv.fr/dist/mail-proconnect.png"
+                            alt="ProConnect"
+                            height="73"
+                            width="193"
+                          />
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="font-size: 64px; line-height: 64px"
+                  >
+                    <tbody>
+                      <tr>
+                        <td> </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    bgcolor="#FFFFFF"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="box-shadow: 0px 2px 6px 0px rgba(0, 0, 18, 0.16)"
+                  >
+                    <tbody>
+                      <tr>
+                        <td>
+                          <table
+                            align="center"
+                            width="100%"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 64px; line-height: 64px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td> </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table
+                            align="center"
+                            width="600"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="max-width: 600px; width: 100%; padding: 24px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="
+                                      color: #000;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-weight: 400;
+                                      line-height: 24px;
+                                      margin: 0;
+                                    "
+                                  >
+                                    Bonjour Marie Dupont,
+                                  </p>
+                                  <br />
+                                  <p
+                                    style="
+                                      color: #000;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-weight: 400;
+                                      line-height: 24px;
+                                      margin: 0;
+                                    "
+                                  >
+                                    Nous vous confirmons que votre demande de
+                                    rattachement à l'organisation
+                                    <span style="white-space: nowrap"
+                                      >« <b>Ministère de la Culture</b> »</span
+                                    >
+                                    a bien été annulée.<br /><br />Si vous
+                                    n'êtes pas à l'origine de cette annulation,
+                                    ou si vous souhaitez de nouveau rejoindre
+                                    cette organisation, vous pouvez renouveler
+                                    votre demande depuis votre espace
+                                    ProConnect.
+                                  </p>
+                                  <p
+                                    style="
+                                      color: #000;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-weight: 400;
+                                      line-height: 24px;
+                                      margin: 0;
+                                      margin-top: 16px;
+                                    "
+                                  >
+                                    Cordialement,<br />L'équipe ProConnect
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table
+                            align="center"
+                            width="100%"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 64px; line-height: 64px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td> </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="font-size: 64px; line-height: 64px"
+                  >
+                    <tbody>
+                      <tr>
+                        <td> </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <table
+            align="center"
+            width="100%"
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+            style="font-size: 64px; line-height: 64px"
+          >
+            <tbody>
+              <tr>
+                <td> </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+
+`;

--- a/packages/email/src/CancelModeration.tsx
+++ b/packages/email/src/CancelModeration.tsx
@@ -1,0 +1,38 @@
+//
+
+import { Layout } from "./_layout.js";
+import { NoWrap, Text } from "./components/index.js";
+
+//
+
+export default function CancelModeration(props: Props) {
+  const { given_name, family_name, libelle } = props;
+  return (
+    <Layout>
+      <Text safe>
+        Bonjour {given_name} {family_name},
+      </Text>
+      <br />
+      <Text>
+        Nous vous confirmons que votre demande de rattachement à l'organisation{" "}
+        <NoWrap>
+          « <b safe>{libelle}</b> »
+        </NoWrap>{" "}
+        a bien été annulée.
+        <br />
+        <br />
+        Si vous n'êtes pas à l'origine de cette annulation, ou si vous souhaitez
+        de nouveau rejoindre cette organisation, vous pouvez renouveler votre
+        demande depuis votre espace ProConnect.
+      </Text>
+    </Layout>
+  );
+}
+
+//
+
+export type Props = {
+  given_name: string;
+  family_name: string;
+  libelle: string;
+};

--- a/packages/email/src/components/NoWrap.tsx
+++ b/packages/email/src/components/NoWrap.tsx
@@ -1,0 +1,15 @@
+//
+
+import type { PropsWithChildren } from "@kitajs/html";
+
+//
+
+export function NoWrap(attributes: PropsWithChildren<JSX.HtmlTag>) {
+  const { children, style, ...props } = attributes;
+
+  return (
+    <span style={{ whiteSpace: "nowrap", ...(style as object) }} {...props}>
+      {children}
+    </span>
+  );
+}

--- a/packages/email/src/components/index.ts
+++ b/packages/email/src/components/index.ts
@@ -5,6 +5,7 @@ export * from "./Button.js";
 export * from "./Em.js";
 export * from "./Html.js";
 export * from "./Link.js";
+export * from "./NoWrap.js";
 export * from "./ProConnectLogo.js";
 export * from "./Section.js";
 export * from "./Text.js";

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -2,6 +2,7 @@
 
 export { default as Add2fa } from "./Add2fa.js";
 export { default as AddAccessKey } from "./AddAccessKey.js";
+export { default as CancelModeration } from "./CancelModeration.js";
 export { default as Delete2faProtection } from "./Delete2faProtection.js";
 export { default as DeleteAccessKey } from "./DeleteAccessKey.js";
 export { default as DeleteAccount } from "./DeleteAccount.js";

--- a/src/managers/moderation.ts
+++ b/src/managers/moderation.ts
@@ -1,7 +1,9 @@
+import { CancelModeration } from "@proconnect-gouv/proconnect.email";
 import { NotFoundError } from "@proconnect-gouv/proconnect.identite/errors";
 import type { User } from "@proconnect-gouv/proconnect.identite/types";
 import { isEmpty } from "lodash-es";
 import { ForbiddenError } from "../config/errors";
+import { sendMail } from "../connectors/mail";
 import {
   deleteModeration,
   findModerationById,
@@ -48,7 +50,25 @@ export const cancelModeration = async ({
     throw new ForbiddenError();
   }
 
-  return await deleteModeration(moderation_id);
+  const organization = await findOrganizationById(moderation.organization_id);
+  if (!organization) {
+    throw new NotFoundError();
+  }
+
+  const result = await deleteModeration(moderation_id);
+
+  await sendMail({
+    to: [user.email],
+    subject: "Annulation de votre demande de rattachement",
+    html: CancelModeration({
+      given_name: user.given_name ?? "",
+      family_name: user.family_name ?? "",
+      libelle: organization.cached_libelle || organization.siret,
+    }).toString(),
+    tag: "cancel-moderation",
+  });
+
+  return result;
 };
 
 export const reopenModerationWithUserEdit = async ({


### PR DESCRIPTION
**Problem**
Cancelling a pending organization-join moderation demand (`cancelModeration`) only deleted the row and showed a flash message; the user never received a written trace of the cancellation, which is needed for historical and contractual record-keeping.

**Proposal**
Add a `CancelModeration` email template and send it to the user right after the moderation record is deleted, following the existing `sendMail`/template pattern used for other account-lifecycle emails.