### PR TITLE
 🧹 chore: remove unused ZAMMAD_TOKEN environment variable

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -10,7 +10,6 @@ env:
   DEBOUNCE_API_KEY: ${{ secrets.DEBOUNCE_API_KEY }}
   FRANCECONNECT_ISSUER: http://localhost:3000/___testing___/oidc.franceconnect.gouv.fr/api/v2
   SMTP_URL: smtp://localhost:1025
-  ZAMMAD_TOKEN: ${{ secrets.ZAMMAD_TOKEN }}
 
 jobs:
   test:


### PR DESCRIPTION
**Problem**
The `ZAMMAD_TOKEN` environment variable is no longer used.

**Proposal**
Remove the unused `ZAMMAD_TOKEN` environment variable.