### PR TITLE
♻️ identite: migrate organization setters to connectors

### DIFF
--- a/.changeset/wire-organization-setters-through-context.md
+++ b/.changeset/wire-organization-setters-through-context.md
@@ -1,0 +1,5 @@
+---
+"@proconnect-gouv/proconnect.identite": patch
+---
+
+add deleteUserOrganizationFactory and wire upsert/linkUserToOrganization into connectors context

--- a/packages/identite/src/connectors/index.ts
+++ b/packages/identite/src/connectors/index.ts
@@ -7,9 +7,12 @@ import { type Pool } from "pg";
 import { addDomainFactory } from "../repositories/email-domain/add-domain.js";
 import { deleteEmailDomainsByVerificationTypesFactory } from "../repositories/email-domain/delete-email-domains-by-verification-types.js";
 import { findEmailDomainsByOrganizationIdFactory } from "../repositories/email-domain/find-email-domains-by-organization-id.js";
+import { deleteUserOrganizationFactory } from "../repositories/organization/delete-user-organization.js";
 import { findByIdFactory as findOrganizationByIdFactory } from "../repositories/organization/find-by-id.js";
 import { findByUserIdFactory } from "../repositories/organization/find-by-user-id.js";
 import { getUsersByOrganizationFactory } from "../repositories/organization/get-users-by-organization.js";
+import { linkUserToOrganizationFactory } from "../repositories/organization/link-user-to-organization.js";
+import { upsertFactory } from "../repositories/organization/upsert.js";
 import { createUserFactory } from "../repositories/user/create.js";
 import { findByEmailFactory } from "../repositories/user/find-by-email.js";
 import { findByIdFactory as findUserByIdFactory } from "../repositories/user/find-by-id.js";
@@ -47,9 +50,12 @@ export function createContext({
           findEmailDomainsByOrganizationIdFactory({ pg }),
       },
       organizations: {
+        deleteUserOrganization: deleteUserOrganizationFactory({ pg }),
         findById: findOrganizationByIdFactory({ pg }),
         findByUserId: findByUserIdFactory({ pg }),
         getUsers: getUsersByOrganizationFactory({ pg }),
+        linkUserToOrganization: linkUserToOrganizationFactory({ pg }),
+        upsert: upsertFactory({ pg }),
       },
       users_organizations: {
         update: updateUserOrganizationLinkFactory({ pg }),

--- a/packages/identite/src/repositories/organization/delete-user-organization.test.ts
+++ b/packages/identite/src/repositories/organization/delete-user-organization.test.ts
@@ -1,0 +1,55 @@
+//
+
+import { emptyDatabase, migrate, pg } from "#testing";
+import assert from "node:assert/strict";
+import { before, beforeEach, suite, test } from "node:test";
+import { deleteUserOrganizationFactory } from "./delete-user-organization.js";
+
+//
+
+const deleteUserOrganization = deleteUserOrganizationFactory({ pg: pg as any });
+
+suite("deleteUserOrganizationFactory", () => {
+  before(migrate);
+  beforeEach(emptyDatabase);
+
+  test("should return true when the link exists", async () => {
+    await pg.sql`
+      INSERT INTO organizations
+        (cached_libelle, cached_nom_complet, id, siret, created_at, updated_at)
+      VALUES
+        ('Necron', 'Necrontyr', 1, '⚰️', '1967-12-19', '1967-12-19')
+      ;
+    `;
+    await pg.sql`
+      INSERT INTO users
+        (id, email, created_at, updated_at, given_name, family_name, phone_number, job)
+      VALUES
+        (1, 'lion.eljonson@darkangels.world', '4444-04-04', '4444-04-04', 'lion', 'el''jonson', 'i', 'primarque')
+      ;
+    `;
+    await pg.sql`
+      INSERT INTO users_organizations
+        (user_id, organization_id, created_at, updated_at, verification_type)
+      VALUES
+        (1, 1, '4444-04-04', '4444-04-04', 'domain_not_verified_yet')
+      ;
+    `;
+
+    const result = await deleteUserOrganization({
+      user_id: 1,
+      organization_id: 1,
+    });
+
+    assert.equal(result, true);
+  });
+
+  test("should return false when the link does not exist", async () => {
+    const result = await deleteUserOrganization({
+      user_id: 999,
+      organization_id: 999,
+    });
+
+    assert.equal(result, false);
+  });
+});

--- a/packages/identite/src/repositories/organization/delete-user-organization.ts
+++ b/packages/identite/src/repositories/organization/delete-user-organization.ts
@@ -1,0 +1,25 @@
+//
+
+import type { DatabaseContext } from "#src/types";
+import type { QueryResult } from "pg";
+
+//
+
+export function deleteUserOrganizationFactory({ pg }: DatabaseContext) {
+  return async function deleteUserOrganization({
+    user_id,
+    organization_id,
+  }: {
+    user_id: number;
+    organization_id: number;
+  }) {
+    const { rowCount, affectedRows } = (await pg.query(
+      `
+DELETE FROM users_organizations
+WHERE user_id = $1 AND organization_id = $2`,
+      [user_id, organization_id],
+    )) as QueryResult & { affectedRows?: number };
+
+    return (affectedRows ?? rowCount ?? 0) > 0;
+  };
+}

--- a/packages/identite/src/repositories/organization/index.ts
+++ b/packages/identite/src/repositories/organization/index.ts
@@ -1,5 +1,6 @@
 //
 
+export * from "./delete-user-organization.js";
 export * from "./find-by-id.js";
 export * from "./find-by-user-id.js";
 export * from "./get-users-by-organization.js";

--- a/src/repositories/organization/setters.ts
+++ b/src/repositories/organization/setters.ts
@@ -1,35 +1,7 @@
-import {
-  linkUserToOrganizationFactory,
-  upsertFactory,
-} from "@proconnect-gouv/proconnect.identite/repositories/organization";
-import { updateUserOrganizationLinkFactory } from "@proconnect-gouv/proconnect.identite/repositories/user";
-import { getDatabaseConnection } from "../../connectors/postgres";
+import { context } from "../../connectors/context";
 
-export const upsert = upsertFactory({ pg: getDatabaseConnection() });
+export const { deleteUserOrganization, linkUserToOrganization, upsert } =
+  context.repository.organizations;
 
-export const linkUserToOrganization = linkUserToOrganizationFactory({
-  pg: getDatabaseConnection(),
-});
-
-export const updateUserOrganizationLink = updateUserOrganizationLinkFactory({
-  pg: getDatabaseConnection(),
-});
-
-export const deleteUserOrganization = async ({
-  user_id,
-  organization_id,
-}: {
-  user_id: number;
-  organization_id: number;
-}) => {
-  const connection = getDatabaseConnection();
-
-  const { rowCount } = await connection.query(
-    `
-DELETE FROM users_organizations
-WHERE user_id = $1 AND organization_id = $2`,
-    [user_id, organization_id],
-  );
-
-  return (rowCount ?? 0) > 0;
-};
+export const { update: updateUserOrganizationLink } =
+  context.repository.users_organizations;


### PR DESCRIPTION
**Problem**
- `upsertFactory`, `linkUserToOrganizationFactory`, and `updateUserOrganizationLinkFactory` were already published from `@proconnect-gouv/proconnect.identite` but each was locally re-instantiated in `src/repositories/organization/setters.ts` with its own `getDatabaseConnection()` — bypassing the context wiring.
- `updateUserOrganizationLinkFactory` had a redundant second instance (already wired once under `users_organizations.update`).
- `deleteUserOrganization` was the only genuine raw-SQL function still living in `src/repositories/**`.

**Proposal**
- Wire `upsert` and `linkUserToOrganization` into `createContext().repository.organizations`.
- Migrate `deleteUserOrganization` into a new `deleteUserOrganizationFactory` in `packages/identite/src/repositories/organization/`. Keeps the original `Promise<boolean>` return — pglite (`affectedRows`) vs pg (`rowCount`) duality is absorbed inside the factory via a single typed cast, the caller stays untouched.
- Point all four re-exports in `setters.ts` at `context.repository.*`.