### PR TITLE
♻️ identite: migrate user repository remainder to connectors

### DIFF
--- a/.changeset/migrate-user-repository-remainder.md
+++ b/.changeset/migrate-user-repository-remainder.md
@@ -1,0 +1,5 @@
+---
+"@proconnect-gouv/proconnect.identite": patch
+---
+
+add deleteUserFactory, findByMagicLinkTokenFactory and findByResetPasswordTokenFactory

--- a/packages/identite/src/connectors/index.ts
+++ b/packages/identite/src/connectors/index.ts
@@ -14,8 +14,11 @@ import { getUsersByOrganizationFactory } from "../repositories/organization/get-
 import { linkUserToOrganizationFactory } from "../repositories/organization/link-user-to-organization.js";
 import { upsertFactory } from "../repositories/organization/upsert.js";
 import { createUserFactory } from "../repositories/user/create.js";
+import { deleteUserFactory } from "../repositories/user/delete.js";
 import { findByEmailFactory } from "../repositories/user/find-by-email.js";
 import { findByIdFactory as findUserByIdFactory } from "../repositories/user/find-by-id.js";
+import { findByMagicLinkTokenFactory } from "../repositories/user/find-by-magic-link-token.js";
+import { findByResetPasswordTokenFactory } from "../repositories/user/find-by-reset-password-token.js";
 import { getByIdFactory } from "../repositories/user/get-by-id.js";
 import { getFranceConnectUserInfoFactory } from "../repositories/user/get-franceconnect-user-info.js";
 import { updateUserOrganizationLinkFactory } from "../repositories/user/update-user-organization-link.js";
@@ -62,8 +65,11 @@ export function createContext({
       },
       users: {
         create: createUserFactory({ pg }),
+        delete: deleteUserFactory({ pg }),
         findByEmail: findByEmailFactory({ pg }),
         findById: findUserByIdFactory({ pg }),
+        findByMagicLinkToken: findByMagicLinkTokenFactory({ pg }),
+        findByResetPasswordToken: findByResetPasswordTokenFactory({ pg }),
         getById: getByIdFactory({ pg }),
         getFranceConnectUserInfo: getFranceConnectUserInfoFactory({ pg }),
         update: updateUserFactory({ pg }),

--- a/packages/identite/src/repositories/user/delete.test.ts
+++ b/packages/identite/src/repositories/user/delete.test.ts
@@ -1,0 +1,35 @@
+//
+
+import { emptyDatabase, migrate, pg } from "#testing";
+import assert from "node:assert/strict";
+import { before, beforeEach, suite, test } from "node:test";
+import { deleteUserFactory } from "./delete.js";
+
+//
+
+const deleteUser = deleteUserFactory({ pg: pg as any });
+
+suite("deleteUserFactory", () => {
+  before(migrate);
+  beforeEach(emptyDatabase);
+
+  test("should return true when the user exists", async () => {
+    await pg.sql`
+      INSERT INTO users
+        (id, email, created_at, updated_at, given_name, family_name, phone_number, job)
+      VALUES
+        (1, 'lion.eljonson@darkangels.world', '4444-04-04', '4444-04-04', 'lion', 'el''jonson', 'i', 'primarque')
+      ;
+    `;
+
+    const result = await deleteUser(1);
+
+    assert.equal(result, true);
+  });
+
+  test("should return false when the user does not exist", async () => {
+    const result = await deleteUser(999);
+
+    assert.equal(result, false);
+  });
+});

--- a/packages/identite/src/repositories/user/delete.ts
+++ b/packages/identite/src/repositories/user/delete.ts
@@ -1,0 +1,19 @@
+//
+
+import type { DatabaseContext } from "#src/types";
+import { type QueryResult } from "pg";
+
+//
+
+export function deleteUserFactory({ pg }: DatabaseContext) {
+  return async function deleteUser(id: number) {
+    const { rowCount, affectedRows } = (await pg.query(
+      `
+DELETE FROM users
+WHERE id = $1`,
+      [id],
+    )) as QueryResult & { affectedRows?: number };
+
+    return (affectedRows ?? rowCount ?? 0) > 0;
+  };
+}

--- a/packages/identite/src/repositories/user/find-by-magic-link-token.test.ts
+++ b/packages/identite/src/repositories/user/find-by-magic-link-token.test.ts
@@ -1,0 +1,35 @@
+//
+
+import { emptyDatabase, migrate, pg } from "#testing";
+import assert from "node:assert/strict";
+import { before, beforeEach, suite, test } from "node:test";
+import { findByMagicLinkTokenFactory } from "./find-by-magic-link-token.js";
+
+//
+
+const findByMagicLinkToken = findByMagicLinkTokenFactory({ pg: pg as any });
+
+suite("findByMagicLinkTokenFactory", () => {
+  before(migrate);
+  beforeEach(emptyDatabase);
+
+  test("should find a user by magic_link_token", async () => {
+    await pg.sql`
+      INSERT INTO users
+        (id, email, created_at, updated_at, given_name, family_name, phone_number, job, magic_link_token)
+      VALUES
+        (1, 'lion.eljonson@darkangels.world', '4444-04-04', '4444-04-04', 'lion', 'el''jonson', 'i', 'primarque', 'TOKEN')
+      ;
+    `;
+
+    const user = await findByMagicLinkToken("TOKEN");
+
+    assert.equal(user?.id, 1);
+  });
+
+  test("should return undefined when the token does not exist", async () => {
+    const user = await findByMagicLinkToken("absent");
+
+    assert.equal(user, undefined);
+  });
+});

--- a/packages/identite/src/repositories/user/find-by-magic-link-token.ts
+++ b/packages/identite/src/repositories/user/find-by-magic-link-token.ts
@@ -1,0 +1,20 @@
+//
+
+import type { DatabaseContext, User } from "#src/types";
+import { type QueryResult } from "pg";
+
+//
+
+export function findByMagicLinkTokenFactory({ pg }: DatabaseContext) {
+  return async function findByMagicLinkToken(magic_link_token: string) {
+    const { rows }: QueryResult<User> = await pg.query(
+      `
+SELECT *
+FROM users WHERE magic_link_token = $1
+`,
+      [magic_link_token],
+    );
+
+    return rows.shift();
+  };
+}

--- a/packages/identite/src/repositories/user/find-by-reset-password-token.test.ts
+++ b/packages/identite/src/repositories/user/find-by-reset-password-token.test.ts
@@ -1,0 +1,37 @@
+//
+
+import { emptyDatabase, migrate, pg } from "#testing";
+import assert from "node:assert/strict";
+import { before, beforeEach, suite, test } from "node:test";
+import { findByResetPasswordTokenFactory } from "./find-by-reset-password-token.js";
+
+//
+
+const findByResetPasswordToken = findByResetPasswordTokenFactory({
+  pg: pg as any,
+});
+
+suite("findByResetPasswordTokenFactory", () => {
+  before(migrate);
+  beforeEach(emptyDatabase);
+
+  test("should find a user by reset_password_token", async () => {
+    await pg.sql`
+      INSERT INTO users
+        (id, email, created_at, updated_at, given_name, family_name, phone_number, job, reset_password_token)
+      VALUES
+        (1, 'lion.eljonson@darkangels.world', '4444-04-04', '4444-04-04', 'lion', 'el''jonson', 'i', 'primarque', 'TOKEN')
+      ;
+    `;
+
+    const user = await findByResetPasswordToken("TOKEN");
+
+    assert.equal(user?.id, 1);
+  });
+
+  test("should return undefined when the token does not exist", async () => {
+    const user = await findByResetPasswordToken("absent");
+
+    assert.equal(user, undefined);
+  });
+});

--- a/packages/identite/src/repositories/user/find-by-reset-password-token.ts
+++ b/packages/identite/src/repositories/user/find-by-reset-password-token.ts
@@ -1,0 +1,20 @@
+//
+
+import type { DatabaseContext, User } from "#src/types";
+import { type QueryResult } from "pg";
+
+//
+
+export function findByResetPasswordTokenFactory({ pg }: DatabaseContext) {
+  return async function findByResetPasswordToken(reset_password_token: string) {
+    const { rows }: QueryResult<User> = await pg.query(
+      `
+SELECT *
+FROM users WHERE reset_password_token = $1
+`,
+      [reset_password_token],
+    );
+
+    return rows.shift();
+  };
+}

--- a/packages/identite/src/repositories/user/index.ts
+++ b/packages/identite/src/repositories/user/index.ts
@@ -1,8 +1,11 @@
 //
 
 export * from "./create.js";
+export * from "./delete.js";
 export * from "./find-by-email.js";
 export * from "./find-by-id.js";
+export * from "./find-by-magic-link-token.js";
+export * from "./find-by-reset-password-token.js";
 export * from "./get-by-id.js";
 export * from "./get-franceconnect-user-info.js";
 export * from "./update-user-organization-link.js";

--- a/src/repositories/user.ts
+++ b/src/repositories/user.ts
@@ -1,60 +1,14 @@
-import type { User } from "@proconnect-gouv/proconnect.identite/types";
-import type { QueryResult } from "pg";
 import { context } from "../connectors/context";
-import { getDatabaseConnection } from "../connectors/postgres";
-
-//
 
 export const {
   create,
+  delete: deleteUser,
   findByEmail,
   findById,
+  findByMagicLinkToken,
+  findByResetPasswordToken,
   getById,
   getFranceConnectUserInfo,
   update,
   upsetFranceconnectUserinfo,
 } = context.repository.users;
-
-export const findByMagicLinkToken = async (magic_link_token: string) => {
-  const connection = getDatabaseConnection();
-
-  const { rows }: QueryResult<User> = await connection.query(
-    `
-SELECT *
-FROM users WHERE magic_link_token = $1
-`,
-    [magic_link_token],
-  );
-
-  return rows.shift();
-};
-
-export const findByResetPasswordToken = async (
-  reset_password_token: string,
-) => {
-  const connection = getDatabaseConnection();
-
-  const { rows }: QueryResult<User> = await connection.query(
-    `
-SELECT *
-FROM users WHERE reset_password_token = $1
-`,
-    [reset_password_token],
-  );
-
-  return rows.shift();
-};
-
-export const deleteUser = async (id: number) => {
-  const connection = getDatabaseConnection();
-
-  const { rowCount } = await connection.query(
-    `
-        DELETE FROM users
-        WHERE id = $1
-        RETURNING *`,
-    [id],
-  );
-
-  return (rowCount ?? 0) > 0;
-};


### PR DESCRIPTION
**Problem**
- `src/repositories/user.ts` still held 3 raw-SQL functions: `findByMagicLinkToken`, `findByResetPasswordToken`, `deleteUser`. The other 7 re-exports were already sourced from `context.repository.users`.

**Proposal**
- Add three new factories under `packages/identite/src/repositories/user/`: `find-by-magic-link-token.ts`, `find-by-reset-password-token.ts`, `delete.ts`. Each keeps its prior return shape (`User | undefined` or `boolean`); the pg/pglite result-shape duality is absorbed inside the factory via a typed cast at the boundary, callers stay untouched.
- Wire the three into `createContext().repository.users` and barrel-export from the user domain index.
- Collapse `src/repositories/user.ts` to a pure re-export shim — no raw SQL remains, and 14 existing caller files stay untouched.
- Co-located tests for each new factory.