### PR TITLE
♻️ identite: migrate organization getters remainder to connectors

### DIFF
--- a/.changeset/migrate-organization-getters-remainder.md
+++ b/.changeset/migrate-organization-getters-remainder.md
@@ -1,0 +1,5 @@
+---
+"@proconnect-gouv/proconnect.identite": patch
+---
+
+add findBySiretFactory, findPendingByUserIdFactory, findByVerifiedEmailDomainFactory, getUserOrganizationLinkFactory

--- a/packages/identite/src/connectors/index.ts
+++ b/packages/identite/src/connectors/index.ts
@@ -9,7 +9,11 @@ import { deleteEmailDomainsByVerificationTypesFactory } from "../repositories/em
 import { findEmailDomainsByOrganizationIdFactory } from "../repositories/email-domain/find-email-domains-by-organization-id.js";
 import { deleteUserOrganizationFactory } from "../repositories/organization/delete-user-organization.js";
 import { findByIdFactory as findOrganizationByIdFactory } from "../repositories/organization/find-by-id.js";
+import { findBySiretFactory } from "../repositories/organization/find-by-siret.js";
 import { findByUserIdFactory } from "../repositories/organization/find-by-user-id.js";
+import { findByVerifiedEmailDomainFactory } from "../repositories/organization/find-by-verified-email-domain.js";
+import { findPendingByUserIdFactory } from "../repositories/organization/find-pending-by-user-id.js";
+import { getUserOrganizationLinkFactory } from "../repositories/organization/get-user-organization-link.js";
 import { getUsersByOrganizationFactory } from "../repositories/organization/get-users-by-organization.js";
 import { linkUserToOrganizationFactory } from "../repositories/organization/link-user-to-organization.js";
 import { upsertFactory } from "../repositories/organization/upsert.js";
@@ -55,7 +59,11 @@ export function createContext({
       organizations: {
         deleteUserOrganization: deleteUserOrganizationFactory({ pg }),
         findById: findOrganizationByIdFactory({ pg }),
+        findBySiret: findBySiretFactory({ pg }),
         findByUserId: findByUserIdFactory({ pg }),
+        findByVerifiedEmailDomain: findByVerifiedEmailDomainFactory({ pg }),
+        findPendingByUserId: findPendingByUserIdFactory({ pg }),
+        getUserOrganizationLink: getUserOrganizationLinkFactory({ pg }),
         getUsers: getUsersByOrganizationFactory({ pg }),
         linkUserToOrganization: linkUserToOrganizationFactory({ pg }),
         upsert: upsertFactory({ pg }),

--- a/packages/identite/src/repositories/organization/find-by-siret.test.ts
+++ b/packages/identite/src/repositories/organization/find-by-siret.test.ts
@@ -1,0 +1,35 @@
+//
+
+import { emptyDatabase, migrate, pg } from "#testing";
+import assert from "node:assert/strict";
+import { before, beforeEach, suite, test } from "node:test";
+import { findBySiretFactory } from "./find-by-siret.js";
+
+//
+
+const findBySiret = findBySiretFactory({ pg: pg as any });
+
+suite("findBySiretFactory", () => {
+  before(migrate);
+  beforeEach(emptyDatabase);
+
+  test("should find the organization by siret", async () => {
+    await pg.sql`
+      INSERT INTO organizations
+        (cached_libelle, cached_nom_complet, id, siret, created_at, updated_at)
+      VALUES
+        ('Necron', 'Necrontyr', 1, '⚰️', '1967-12-19', '1967-12-19')
+      ;
+    `;
+
+    const organization = await findBySiret("⚰️");
+
+    assert.equal(organization?.id, 1);
+  });
+
+  test("should return undefined when siret does not exist", async () => {
+    const organization = await findBySiret("absent");
+
+    assert.equal(organization, undefined);
+  });
+});

--- a/packages/identite/src/repositories/organization/find-by-siret.ts
+++ b/packages/identite/src/repositories/organization/find-by-siret.ts
@@ -1,0 +1,21 @@
+//
+
+import type { DatabaseContext, Organization } from "#src/types";
+import { type QueryResult } from "pg";
+
+//
+
+export function findBySiretFactory({ pg }: DatabaseContext) {
+  return async function findBySiret(siret: string) {
+    const { rows }: QueryResult<Organization> = await pg.query(
+      `
+SELECT *
+FROM organizations
+WHERE siret = $1
+`,
+      [siret],
+    );
+
+    return rows.shift();
+  };
+}

--- a/packages/identite/src/repositories/organization/find-by-verified-email-domain.test.ts
+++ b/packages/identite/src/repositories/organization/find-by-verified-email-domain.test.ts
@@ -1,0 +1,46 @@
+//
+
+import { emptyDatabase, migrate, pg } from "#testing";
+import assert from "node:assert/strict";
+import { before, beforeEach, suite, test } from "node:test";
+import { findByVerifiedEmailDomainFactory } from "./find-by-verified-email-domain.js";
+
+//
+
+const findByVerifiedEmailDomain = findByVerifiedEmailDomainFactory({
+  pg: pg as any,
+});
+
+suite("findByVerifiedEmailDomainFactory", () => {
+  before(migrate);
+  beforeEach(emptyDatabase);
+
+  test("should return empty array when no organization matches the domain", async () => {
+    const organizations = await findByVerifiedEmailDomain("absent.world");
+
+    assert.deepEqual(organizations, []);
+  });
+
+  test("should return matching organization with member_count", async () => {
+    await pg.sql`
+      INSERT INTO organizations
+        (cached_libelle, cached_nom_complet, id, siret, created_at, updated_at, cached_est_active)
+      VALUES
+        ('Necron', 'Necrontyr', 1, '⚰️', '1967-12-19', '1967-12-19', 'true')
+      ;
+    `;
+    await pg.sql`
+      INSERT INTO email_domains
+        (organization_id, domain, verification_type, created_at, updated_at)
+      VALUES
+        (1, 'darkangels.world', 'verified', '4444-04-04', '4444-04-04')
+      ;
+    `;
+
+    const organizations = await findByVerifiedEmailDomain("darkangels.world");
+
+    assert.equal(organizations.length, 1);
+    assert.equal(organizations[0]?.id, 1);
+    assert.equal(organizations[0]?.member_count, 0);
+  });
+});

--- a/packages/identite/src/repositories/organization/find-by-verified-email-domain.ts
+++ b/packages/identite/src/repositories/organization/find-by-verified-email-domain.ts
@@ -1,0 +1,33 @@
+//
+
+import type { DatabaseContext } from "#src/types";
+import {
+  EmailDomainApprovedVerificationValues,
+  type Organization,
+} from "#src/types";
+import { type QueryResult } from "pg";
+
+//
+
+export function findByVerifiedEmailDomainFactory({ pg }: DatabaseContext) {
+  return async function findByVerifiedEmailDomain(email_domain: string) {
+    const { rows }: QueryResult<Organization & { member_count: number }> =
+      await pg.query(
+        `
+      SELECT o.*, count(u.id)::int as member_count
+      FROM organizations o
+             INNER JOIN email_domains ed ON ed.organization_id = o.id
+             LEFT JOIN users_organizations uo ON uo.organization_id = o.id
+             LEFT JOIN users u ON u.id = uo.user_id
+        AND substring(u.email FROM '@(.+)$') = $1
+      WHERE o.cached_est_active = 'true'
+        AND ed.domain = $1
+        AND ed.verification_type = ANY ($2)
+      GROUP BY o.id
+      ORDER BY member_count DESC NULLS LAST;`,
+        [email_domain, EmailDomainApprovedVerificationValues],
+      );
+
+    return rows;
+  };
+}

--- a/packages/identite/src/repositories/organization/find-pending-by-user-id.test.ts
+++ b/packages/identite/src/repositories/organization/find-pending-by-user-id.test.ts
@@ -1,0 +1,51 @@
+//
+
+import { emptyDatabase, migrate, pg } from "#testing";
+import assert from "node:assert/strict";
+import { before, beforeEach, suite, test } from "node:test";
+import { findPendingByUserIdFactory } from "./find-pending-by-user-id.js";
+
+//
+
+const findPendingByUserId = findPendingByUserIdFactory({ pg: pg as any });
+
+suite("findPendingByUserIdFactory", () => {
+  before(migrate);
+  beforeEach(emptyDatabase);
+
+  test("should return empty array when user has no pending moderations", async () => {
+    const organizations = await findPendingByUserId(42);
+
+    assert.deepEqual(organizations, []);
+  });
+
+  test("should return pending organizations for a user", async () => {
+    await pg.sql`
+      INSERT INTO organizations
+        (cached_libelle, cached_nom_complet, id, siret, created_at, updated_at)
+      VALUES
+        ('Necron', 'Necrontyr', 1, '⚰️', '1967-12-19', '1967-12-19')
+      ;
+    `;
+    await pg.sql`
+      INSERT INTO users
+        (id, email, created_at, updated_at, given_name, family_name, phone_number, job)
+      VALUES
+        (1, 'lion.eljonson@darkangels.world', '4444-04-04', '4444-04-04', 'lion', 'el''jonson', 'i', 'primarque')
+      ;
+    `;
+    await pg.sql`
+      INSERT INTO moderations
+        (id, user_id, organization_id, type, created_at, moderated_at, comment)
+      VALUES
+        (1, 1, 1, 'organization_join_block', '4444-04-04', NULL, 'pending')
+      ;
+    `;
+
+    const organizations = await findPendingByUserId(1);
+
+    assert.equal(organizations.length, 1);
+    assert.equal(organizations[0]?.id, 1);
+    assert.equal(organizations[0]?.moderation_id, 1);
+  });
+});

--- a/packages/identite/src/repositories/organization/find-pending-by-user-id.ts
+++ b/packages/identite/src/repositories/organization/find-pending-by-user-id.ts
@@ -1,0 +1,27 @@
+//
+
+import type { DatabaseContext } from "#src/types";
+import { ModerationTypeSchema, type Organization } from "#src/types";
+import { type QueryResult } from "pg";
+
+//
+
+export function findPendingByUserIdFactory({ pg }: DatabaseContext) {
+  return async function findPendingByUserId(user_id: number) {
+    const { rows }: QueryResult<Organization & { moderation_id: number }> =
+      await pg.query(
+        `
+SELECT o.*, m.id as moderation_id
+FROM moderations m
+INNER JOIN organizations o on o.id = m.organization_id
+WHERE m.user_id = $1
+AND m.type = $2
+AND m.moderated_at IS NULL
+ORDER BY m.created_at
+`,
+        [user_id, ModerationTypeSchema.enum.organization_join_block],
+      );
+
+    return rows;
+  };
+}

--- a/packages/identite/src/repositories/organization/get-user-organization-link.test.ts
+++ b/packages/identite/src/repositories/organization/get-user-organization-link.test.ts
@@ -1,0 +1,52 @@
+//
+
+import { emptyDatabase, migrate, pg } from "#testing";
+import assert from "node:assert/strict";
+import { before, beforeEach, suite, test } from "node:test";
+import { getUserOrganizationLinkFactory } from "./get-user-organization-link.js";
+
+//
+
+const getUserOrganizationLink = getUserOrganizationLinkFactory({
+  pg: pg as any,
+});
+
+suite("getUserOrganizationLinkFactory", () => {
+  before(migrate);
+  beforeEach(emptyDatabase);
+
+  test("should return undefined when the link does not exist", async () => {
+    const link = await getUserOrganizationLink(1, 1);
+
+    assert.equal(link, undefined);
+  });
+
+  test("should return the link when it exists", async () => {
+    await pg.sql`
+      INSERT INTO organizations
+        (cached_libelle, cached_nom_complet, id, siret, created_at, updated_at)
+      VALUES
+        ('Necron', 'Necrontyr', 1, '⚰️', '1967-12-19', '1967-12-19')
+      ;
+    `;
+    await pg.sql`
+      INSERT INTO users
+        (id, email, created_at, updated_at, given_name, family_name, phone_number, job)
+      VALUES
+        (1, 'lion.eljonson@darkangels.world', '4444-04-04', '4444-04-04', 'lion', 'el''jonson', 'i', 'primarque')
+      ;
+    `;
+    await pg.sql`
+      INSERT INTO users_organizations
+        (user_id, organization_id, created_at, updated_at, verification_type)
+      VALUES
+        (1, 1, '4444-04-04', '4444-04-04', 'domain_not_verified_yet')
+      ;
+    `;
+
+    const link = await getUserOrganizationLink(1, 1);
+
+    assert.equal(link?.user_id, 1);
+    assert.equal(link?.organization_id, 1);
+  });
+});

--- a/packages/identite/src/repositories/organization/get-user-organization-link.ts
+++ b/packages/identite/src/repositories/organization/get-user-organization-link.ts
@@ -1,0 +1,34 @@
+//
+
+import type { DatabaseContext, UserOrganizationLink } from "#src/types";
+import { type QueryResult } from "pg";
+
+//
+
+export function getUserOrganizationLinkFactory({ pg }: DatabaseContext) {
+  return async function getUserOrganizationLink(
+    organization_id: number,
+    user_id: number,
+  ) {
+    const { rows }: QueryResult<UserOrganizationLink> = await pg.query(
+      `
+SELECT
+  user_id,
+  organization_id,
+  is_external,
+  created_at,
+  updated_at,
+  verification_type,
+  verified_at,
+  has_been_greeted,
+  needs_official_contact_email_verification,
+  official_contact_email_verification_token,
+  official_contact_email_verification_sent_at
+FROM users_organizations
+WHERE organization_id = $1 AND user_id = $2`,
+      [organization_id, user_id],
+    );
+
+    return rows.shift();
+  };
+}

--- a/packages/identite/src/repositories/organization/index.ts
+++ b/packages/identite/src/repositories/organization/index.ts
@@ -2,7 +2,11 @@
 
 export * from "./delete-user-organization.js";
 export * from "./find-by-id.js";
+export * from "./find-by-siret.js";
 export * from "./find-by-user-id.js";
+export * from "./find-by-verified-email-domain.js";
+export * from "./find-pending-by-user-id.js";
+export * from "./get-user-organization-link.js";
 export * from "./get-users-by-organization.js";
 export * from "./link-user-to-organization.js";
 export * from "./upsert.js";

--- a/src/repositories/organization/getters.ts
+++ b/src/repositories/organization/getters.ts
@@ -1,97 +1,11 @@
-import {
-  EmailDomainApprovedVerificationValues,
-  ModerationTypeSchema,
-  type Organization,
-  type UserOrganizationLink,
-} from "@proconnect-gouv/proconnect.identite/types";
-import type { QueryResult } from "pg";
 import { context } from "../../connectors/context";
-import { getDatabaseConnection } from "../../connectors/postgres";
 
-export const { findById, findByUserId, getUsers } =
-  context.repository.organizations;
-
-export const findBySiret = async (siret: string) => {
-  const connection = getDatabaseConnection();
-
-  const { rows }: QueryResult<Organization> = await connection.query(
-    `
-SELECT *
-FROM organizations
-WHERE siret = $1
-`,
-    [siret],
-  );
-
-  return rows.shift();
-};
-
-export const findPendingByUserId = async (user_id: number) => {
-  const connection = getDatabaseConnection();
-
-  const { rows }: QueryResult<Organization & { moderation_id: number }> =
-    await connection.query(
-      `
-SELECT o.*, m.id as moderation_id
-FROM moderations m
-INNER JOIN organizations o on o.id = m.organization_id
-WHERE m.user_id = $1
-AND m.type = $2
-AND m.moderated_at IS NULL
-ORDER BY m.created_at
-`,
-      [user_id, ModerationTypeSchema.enum.organization_join_block],
-    );
-
-  return rows;
-};
-export const findByVerifiedEmailDomain = async (email_domain: string) => {
-  const connection = getDatabaseConnection();
-
-  const { rows }: QueryResult<Organization & { member_count: number }> =
-    await connection.query(
-      `
-      SELECT o.*, count(u.id)::int as member_count
-      FROM organizations o
-             INNER JOIN email_domains ed ON ed.organization_id = o.id
-             LEFT JOIN users_organizations uo ON uo.organization_id = o.id
-             LEFT JOIN users u ON u.id = uo.user_id
-        AND substring(u.email FROM '@(.+)$') = $1
-      WHERE o.cached_est_active = 'true'
-        AND ed.domain = $1
-        AND ed.verification_type = ANY ($2)
-      GROUP BY o.id
-      ORDER BY member_count DESC NULLS LAST;`,
-      [email_domain, EmailDomainApprovedVerificationValues],
-    );
-
-  return rows;
-};
-
-export const getUserOrganizationLink = async (
-  organization_id: number,
-  user_id: number,
-) => {
-  const connection = getDatabaseConnection();
-
-  const { rows }: QueryResult<UserOrganizationLink> = await connection.query(
-    `
-SELECT
-  user_id,
-  organization_id,
-  is_external,
-  created_at,
-  updated_at,
-  verification_type,
-  verified_at,
-  has_been_greeted,
-  needs_official_contact_email_verification,
-  official_contact_email_verification_token,
-  official_contact_email_verification_sent_at
-FROM users_organizations
-WHERE organization_id = $1 AND user_id = $2`,
-    [organization_id, user_id],
-  );
-
-  return rows.shift();
-};
+export const {
+  findById,
+  findBySiret,
+  findByUserId,
+  findByVerifiedEmailDomain,
+  findPendingByUserId,
+  getUserOrganizationLink,
+  getUsers,
+} = context.repository.organizations;


### PR DESCRIPTION
**Problem**
- `src/repositories/organization/getters.ts` (97 lines) re-exported `findById`/`findByUserId`/`getUsers` from `context.repository.organizations` but still held 4 raw-SQL functions: `findBySiret`, `findPendingByUserId`, `findByVerifiedEmailDomain`, `getUserOrganizationLink`.

**Proposal**
- Add 4 new factories under `packages/identite/src/repositories/organization/`: `find-by-siret.ts`, `find-pending-by-user-id.ts`, `find-by-verified-email-domain.ts`, `get-user-organization-link.ts`. Each keeps its prior return shape (`Organization | undefined` or `Array<...>`); pglite/pg compatibility is free because they only read `rows`.
- Wire the 4 into `createContext().repository.organizations` and barrel-export from the organization domain index.
- Collapse `src/repositories/organization/getters.ts` to a pure re-export shim — no raw SQL remains, and existing caller files stay untouched.
- Co-located tests for each new factory (8 tests across 4 suites).