### PR TITLE
🐧 Add a flake for nix users

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,3 +71,9 @@ updates:
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
+  - package-ecosystem: "nix"
+    directory: "/"
+    labels:
+      - dependencies
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This guide provides steps to run the ProConnect Identité Node.js application lo
 
 ### Prerequisites
 
-- Node.js (v22) installed locally (we suggest the usage of [nvm](https://github.com/nvm-sh/nvm))
+- Node.js (v22) installed locally (we suggest the usage of [nvm](https://github.com/nvm-sh/nvm)), or run `nix develop` to get a shell with the correct Node.js version (see `flake.nix`)
 - Docker (>= v25) and Docker Compose (>= v2.24) installed ([doc](https://docs.docker.com/engine/install/))
 - Clone the ProConnect Identité repository
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,21 @@
           # matches "engines.node" in package.json (^24.11.0); npm ships with nodejs
           packages = [
             pkgs.nodejs_24
+            pkgs.cypress
           ];
+
+          # npm's downloaded Cypress binary can't dynamically link on NixOS;
+          # run nixpkgs' Cypress instead. Version tracks nixpkgs-unstable, not
+          # package.json's pinned "cypress" range — recheck on cypress major bumps.
+          #
+          # CYPRESS_SKIP_VERIFY: the store path is read-only, and Cypress'
+          # verify step tries to write binary_state.json next to the binary
+          # (cypress-io/cypress#30684) — skip it, npm's cypress CLI still runs.
+          shellHook = ''
+            export CYPRESS_INSTALL_BINARY=0
+            export CYPRESS_RUN_BINARY="${pkgs.cypress}/bin/Cypress"
+            export CYPRESS_SKIP_VERIFY=true
+          '';
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "ProConnect Identité flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = inputs.nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          # matches "engines.node" in package.json (^24.11.0); npm ships with nodejs
+          packages = [
+            pkgs.nodejs_24
+          ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,25 +12,34 @@
       system:
       let
         pkgs = inputs.nixpkgs.legacyPackages.${system};
+
+        # pin to match "cypress" in package.json exactly — nixpkgs-unstable's
+        # cypress drifts from it otherwise. Bump both together.
+        cypress = pkgs.cypress.overrideAttrs (old: rec {
+          version = "15.15.0";
+          src = pkgs.fetchurl {
+            url = "https://cdn.cypress.io/desktop/${version}/linux-x64/cypress.zip";
+            hash = "sha256-ekFa9RO8vCcSEhlHWHw7/uwILmfSS4oyFiJWU4kWlQc=";
+          };
+        });
       in
       {
         devShells.default = pkgs.mkShell {
           # matches "engines.node" in package.json (^24.11.0); npm ships with nodejs
           packages = [
             pkgs.nodejs_24
-            pkgs.cypress
+            cypress
           ];
 
           # npm's downloaded Cypress binary can't dynamically link on NixOS;
-          # run nixpkgs' Cypress instead. Version tracks nixpkgs-unstable, not
-          # package.json's pinned "cypress" range — recheck on cypress major bumps.
+          # run nixpkgs' (version-pinned, see above) Cypress instead.
           #
           # CYPRESS_SKIP_VERIFY: the store path is read-only, and Cypress'
           # verify step tries to write binary_state.json next to the binary
           # (cypress-io/cypress#30684) — skip it, npm's cypress CLI still runs.
           shellHook = ''
             export CYPRESS_INSTALL_BINARY=0
-            export CYPRESS_RUN_BINARY="${pkgs.cypress}/bin/Cypress"
+            export CYPRESS_RUN_BINARY="${cypress}/bin/Cypress"
             export CYPRESS_SKIP_VERIFY=true
           '';
         };


### PR DESCRIPTION
DelelopIX desktops doesn't come with a global install of node/nvm or anything like this. 

This is a sudoless solution to have a shell with the tools we need :)
