### PR TITLE
Revert "♻️  Use absolute include paths in MFA settings views"

### DIFF
--- a/src/services/renderer.ts
+++ b/src/services/renderer.ts
@@ -22,8 +22,6 @@ let manifest: Record<
   }
 > | null = null;
 
-const viewsPath = path.resolve(import.meta.dirname, "..", "views");
-
 const viteAssetPath = (name: string) => {
   // cache the manifest file only in production
   if (NODE_ENV !== "production" || manifest === null) {
@@ -114,9 +112,6 @@ export const ejsLayoutMiddlewareFactory = (
   app: Application,
   use_dashboard_layout: boolean = false,
 ) => {
-  app.engine("ejs", (filePath, options, callback) => {
-    ejs.renderFile(filePath, options, { root: viewsPath }, callback);
-  });
   return (req: Request, res: Response, next: NextFunction) => {
     const orig = res.render;
     res.render = (view, locals = {}) => {

--- a/src/views/double-authentication-choice.ejs
+++ b/src/views/double-authentication-choice.ejs
@@ -1,7 +1,7 @@
 <div class="dashboard-container">
-  <%- include('/partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
+  <%- include('partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
   <div class="dashboard-content fr-col-12 fr-col-lg-10 fr-col-xl-9 fr-col-offset-lg-1">
-    <%- include('/mfa-settings/double-authentication-choice-layout.ejs', {
+    <%- include('mfa-settings/double-authentication-choice-layout.ejs', {
       withInfoAlert: false,
       isTotpAppInstalledUrl: '/is-totp-app-installed',
       verifyRegistrationAction: '/passkeys/verify-registration',

--- a/src/views/is-totp-app-installed.ejs
+++ b/src/views/is-totp-app-installed.ejs
@@ -1,7 +1,7 @@
 <div class="dashboard-container">
-  <%- include('/partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
+  <%- include('partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
   <div class="dashboard-content fr-col-12 fr-col-lg-10 fr-col-xl-9 fr-col-offset-lg-1">
-    <%- include('/mfa-settings/is-totp-app-installed-layout.ejs', {
+    <%- include('mfa-settings/is-totp-app-installed-layout.ejs', {
       totpConfigurationUrl: '/totp-configuration',
     }); %>
   </div>

--- a/src/views/mfa-decision-helper/can-install-software/external-help-needed.ejs
+++ b/src/views/mfa-decision-helper/can-install-software/external-help-needed.ejs
@@ -1,6 +1,6 @@
 <div class="dashboard-container">
-  <%- include('/partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
+  <%- include('../../partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
   <div class="dashboard-content fr-col-12 fr-col-lg-10 fr-col-xl-9 fr-col-offset-lg-1">
-    <%- include('/mfa-settings/external-help-needed-layout.ejs'); %>
+    <%- include('../../mfa-settings/external-help-needed-layout.ejs'); %>
   </div>
 </div>

--- a/src/views/mfa-decision-helper/can-install-software/index.ejs
+++ b/src/views/mfa-decision-helper/can-install-software/index.ejs
@@ -1,7 +1,7 @@
 <div class="dashboard-container">
-  <%- include('/partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
+  <%- include('../../partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
   <div class="dashboard-content fr-col-12 fr-col-lg-10 fr-col-xl-9 fr-col-offset-lg-1">
-    <%- include('/mfa-settings/can-install-software-layout.ejs', {
+    <%- include('../../mfa-settings/can-install-software-layout.ejs', {
       formAction: '/mfa-decision-helper/can-install-software',
     }); %>
   </div>

--- a/src/views/mfa-decision-helper/can-install-software/smartphone-app.ejs
+++ b/src/views/mfa-decision-helper/can-install-software/smartphone-app.ejs
@@ -1,7 +1,7 @@
 <div class="dashboard-container">
-  <%- include('/partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
+  <%- include('../../partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
   <div class="dashboard-content fr-col-12 fr-col-lg-10 fr-col-xl-9 fr-col-offset-lg-1">
-    <%- include('/mfa-settings/smartphone-app-layout.ejs', {
+    <%- include('../../mfa-settings/smartphone-app-layout.ejs', {
       totpRecommendationPath: '../mfa-decision-helper/totp-recommendation.ejs',
     }); %>
   </div>

--- a/src/views/mfa-decision-helper/can-install-software/smartphone.ejs
+++ b/src/views/mfa-decision-helper/can-install-software/smartphone.ejs
@@ -1,7 +1,7 @@
 <div class="dashboard-container">
-  <%- include('/partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
+  <%- include('../../partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
   <div class="dashboard-content fr-col-12 fr-col-lg-10 fr-col-xl-9 fr-col-offset-lg-1">
-    <%- include('/mfa-settings/smartphone-layout.ejs', {
+    <%- include('../../mfa-settings/smartphone-layout.ejs', {
       formAction: '/mfa-decision-helper/can-install-software/smartphone',
     }); %>
   </div>

--- a/src/views/mfa-decision-helper/can-install-software/software.ejs
+++ b/src/views/mfa-decision-helper/can-install-software/software.ejs
@@ -1,7 +1,7 @@
 <div class="dashboard-container">
-  <%- include('/partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
+  <%- include('../../partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
   <div class="dashboard-content fr-col-12 fr-col-lg-10 fr-col-xl-9 fr-col-offset-lg-1">
-    <%- include('/mfa-settings/software-layout.ejs', {
+    <%- include('../../mfa-settings/software-layout.ejs', {
       totpRecommendationPath: '../mfa-decision-helper/totp-recommendation.ejs',
     }); %>
   </div>

--- a/src/views/mfa-decision-helper/index.ejs
+++ b/src/views/mfa-decision-helper/index.ejs
@@ -1,7 +1,7 @@
 <div class="dashboard-container">
-  <%- include('/partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
+  <%- include('../partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
   <div class="dashboard-content fr-col-12 fr-col-lg-10 fr-col-xl-9 fr-col-offset-lg-1">
-    <%- include('/mfa-settings/index-layout.ejs', {
+    <%- include('../mfa-settings/index-layout.ejs', {
       formAction: '/mfa-decision-helper',
     }); %>
   </div>

--- a/src/views/mfa-decision-helper/passkey.ejs
+++ b/src/views/mfa-decision-helper/passkey.ejs
@@ -1,7 +1,7 @@
 <div class="dashboard-container">
-  <%- include('/partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
+  <%- include('../partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
   <div class="dashboard-content fr-col-12 fr-col-lg-10 fr-col-xl-9 fr-col-offset-lg-1">
-    <%- include('/mfa-settings/passkey-layout.ejs', {
+    <%- include('../mfa-settings/passkey-layout.ejs', {
       notifications: notifications,
       csrfToken: csrfToken,
       verifyRegistrationAction: '/passkeys/verify-registration',

--- a/src/views/mfa-decision-helper/totp-recommendation.ejs
+++ b/src/views/mfa-decision-helper/totp-recommendation.ejs
@@ -1,4 +1,4 @@
-<%- include('/mfa-settings/totp-recommendation-layout.ejs', {
+<%- include('../mfa-settings/totp-recommendation-layout.ejs', {
   description: description,
   toolTypeLabel: toolTypeLabel,
   tools: tools,

--- a/src/views/mfa-settings/can-install-software-layout.ejs
+++ b/src/views/mfa-settings/can-install-software-layout.ejs
@@ -1,4 +1,4 @@
-<%- include('/partials/mfa-decision-helper-header.ejs', { step: "two" }); %>
+<%- include('../partials/mfa-decision-helper-header.ejs', { step: "two" }); %>
 
 <form action="<%= formAction %>" method="get">
   <fieldset
@@ -43,4 +43,4 @@
   <button class="fr-btn btn--fullwidth" type="submit">Continuer</button>
 </form>
 
-<%- include('/partials/mfa-helper-restart.ejs'); %>
+<%- include('../partials/mfa-helper-restart.ejs'); %>

--- a/src/views/mfa-settings/double-authentication-choice-layout.ejs
+++ b/src/views/mfa-settings/double-authentication-choice-layout.ejs
@@ -62,7 +62,7 @@
   <button class="fr-btn btn--fullwidth" type="submit" id="webauthn-registration-button">Continuer</button>
 </form>
 
-<%- include('/partials/go-back.ejs'); %>
+<%- include('../partials/go-back.ejs'); %>
 
 <form
   id="webauthn-registration-response-form"

--- a/src/views/mfa-settings/external-help-needed-layout.ejs
+++ b/src/views/mfa-settings/external-help-needed-layout.ejs
@@ -1,4 +1,4 @@
-<%- include('/partials/mfa-decision-helper-header.ejs', { step: "three" }); %>
+<%- include('../partials/mfa-decision-helper-header.ejs', { step: "three" }); %>
 
 <div class="fr-grid-row fr-grid-row--middle fr-mb-2w">
   <img src="/dist/error.svg" alt="" class="limited-width fr-mr-2w" />
@@ -10,4 +10,4 @@
   informatique pour qu’ils vous fournissent des outils de 2FA.
 </p>
 
-<%- include('/partials/mfa-helper-restart.ejs'); %>
+<%- include('../partials/mfa-helper-restart.ejs'); %>

--- a/src/views/mfa-settings/index-layout.ejs
+++ b/src/views/mfa-settings/index-layout.ejs
@@ -1,4 +1,4 @@
-<%- include('/partials/mfa-decision-helper-header.ejs', { step: "one" }); %>
+<%- include('../partials/mfa-decision-helper-header.ejs', { step: "one" }); %>
 
 <form action="<%= formAction %>" method="get">
   <fieldset
@@ -62,4 +62,4 @@
   <button class="fr-btn btn--fullwidth" type="submit">Continuer</button>
 </form>
 
-<%- include('/partials/mfa-helper-restart.ejs'); %>
+<%- include('../partials/mfa-helper-restart.ejs'); %>

--- a/src/views/mfa-settings/is-totp-app-installed-layout.ejs
+++ b/src/views/mfa-settings/is-totp-app-installed-layout.ejs
@@ -1,4 +1,4 @@
-<%- include('/partials/stepper.ejs', {currentStep: "1", stepsTitle: "Configurer votre outil TOTP", nextStepTitle:"Configurer votre application TOTP" }); %>
+<%- include('../partials/stepper.ejs', {currentStep: "1", stepsTitle: "Configurer votre outil TOTP", nextStepTitle:"Configurer votre application TOTP" }); %>
 
 <form action="<%= totpConfigurationUrl %>" class="checkbox-container" method="get">
   <fieldset
@@ -65,4 +65,4 @@
   </button>
 </form>
 
-<%- include('/partials/go-back.ejs'); %>
+<%- include('../partials/go-back.ejs'); %>

--- a/src/views/mfa-settings/passkey-layout.ejs
+++ b/src/views/mfa-settings/passkey-layout.ejs
@@ -1,6 +1,6 @@
-<%- include('/partials/notifications.ejs', {notifications: notifications}) %>
+<%- include('../partials/notifications.ejs', {notifications: notifications}) %>
 
-<%- include('/partials/mfa-decision-helper-header.ejs', { step: "three" }); %>
+<%- include('../partials/mfa-decision-helper-header.ejs', { step: "three" }); %>
 
 <div class="fr-callout fr-icon-alert-line" id="webauthn-not-supported" hidden>
   <p class="fr-callout__title fr-h4">
@@ -39,7 +39,7 @@
   Continuer avec la passkey
 </button>
 
-<%- include('/partials/mfa-helper-restart.ejs'); %>
+<%- include('../partials/mfa-helper-restart.ejs'); %>
 
 <form
   id="webauthn-registration-response-form"

--- a/src/views/mfa-settings/smartphone-app-layout.ejs
+++ b/src/views/mfa-settings/smartphone-app-layout.ejs
@@ -1,4 +1,4 @@
-<%- include('/partials/mfa-decision-helper-header.ejs', { step: "three" }); %>
+<%- include('../partials/mfa-decision-helper-header.ejs', { step: "three" }); %>
 
 <%- include(totpRecommendationPath, {
   description: "Une application smartphone génère un code qui change toutes les 30 secondes.",
@@ -10,4 +10,4 @@
   ]
 }) %>
 
-<%- include('/partials/mfa-helper-restart.ejs'); %>
+<%- include('../partials/mfa-helper-restart.ejs'); %>

--- a/src/views/mfa-settings/smartphone-layout.ejs
+++ b/src/views/mfa-settings/smartphone-layout.ejs
@@ -1,4 +1,4 @@
-<%- include('/partials/mfa-decision-helper-header.ejs', { step: "two" }); %>
+<%- include('../partials/mfa-decision-helper-header.ejs', { step: "two" }); %>
 
 <form action="<%= formAction %>" method="get">
   <fieldset
@@ -46,4 +46,4 @@
   <button class="fr-btn btn--fullwidth" type="submit">Continuer</button>
 </form>
 
-<%- include('/partials/mfa-helper-restart.ejs'); %>
+<%- include('../partials/mfa-helper-restart.ejs'); %>

--- a/src/views/mfa-settings/software-layout.ejs
+++ b/src/views/mfa-settings/software-layout.ejs
@@ -1,4 +1,4 @@
-<%- include('/partials/mfa-decision-helper-header.ejs', { step: "three" }); %>
+<%- include('../partials/mfa-decision-helper-header.ejs', { step: "three" }); %>
 
 <%- include(totpRecommendationPath, {
   description: "Un logiciel ou une extension de navigateur génère un code qui change toutes les 30 secondes.",
@@ -10,4 +10,4 @@
   ]
 }) %>
 
-<%- include('/partials/mfa-helper-restart.ejs'); %>
+<%- include('../partials/mfa-helper-restart.ejs'); %>

--- a/src/views/mfa-settings/totp-configuration-layout.ejs
+++ b/src/views/mfa-settings/totp-configuration-layout.ejs
@@ -1,5 +1,5 @@
-<%- include('/partials/notifications.ejs', {notifications: notifications}) %>
-<%- include('/partials/stepper.ejs', {currentStep: "2", stepsTitle: "Configurer votre application TOTP", nextStepTitle: nextStepTitle }); %>
+<%- include('../partials/notifications.ejs', {notifications: notifications}) %>
+<%- include('../partials/stepper.ejs', {currentStep: "2", stepsTitle: "Configurer votre application TOTP", nextStepTitle: nextStepTitle }); %>
 
 <% if (locals.isAuthenticatorAlreadyConfigured) { %>
     <h2>Changer d’application d’authentification</h2>

--- a/src/views/totp-configuration.ejs
+++ b/src/views/totp-configuration.ejs
@@ -1,7 +1,7 @@
 <div class="dashboard-container">
-    <%- include('/partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
+    <%- include('partials/sidemenu.ejs', {activeLink: 'connection-and-account'}) %>
     <div class="dashboard-content fr-col-12 fr-col-lg-10 fr-col-xl-9 fr-col-offset-lg-1">
-        <%- include('/mfa-settings/totp-configuration-layout.ejs', {
+        <%- include('mfa-settings/totp-configuration-layout.ejs', {
             nextStepTitle: "Votre double authentification est bien configurée",
             totpConfigurationUrl: '/totp-configuration',
             cancelUrl: '/connection-and-account',

--- a/src/views/user/double-authentication-choice.ejs
+++ b/src/views/user/double-authentication-choice.ejs
@@ -1,7 +1,7 @@
 <div>
-  <%- include('/partials/notifications.ejs', {notifications: notifications}) %>
+  <%- include('../partials/notifications.ejs', {notifications: notifications}) %>
 
-  <%- include('/mfa-settings/double-authentication-choice-layout.ejs', {
+  <%- include('../mfa-settings/double-authentication-choice-layout.ejs', {
     withInfoAlert: true,
     isTotpAppInstalledUrl: '/users/is-totp-app-installed',
     verifyRegistrationAction: '/users/passkeys/verify-registration',

--- a/src/views/user/is-totp-app-installed.ejs
+++ b/src/views/user/is-totp-app-installed.ejs
@@ -1,5 +1,5 @@
 <div>
-  <%- include('/mfa-settings/is-totp-app-installed-layout.ejs', {
+  <%- include('../mfa-settings/is-totp-app-installed-layout.ejs', {
     totpConfigurationUrl: '/users/totp-configuration',
   }); %>
 </div>

--- a/src/views/user/mfa-decision-helper/can-install-software/external-help-needed.ejs
+++ b/src/views/user/mfa-decision-helper/can-install-software/external-help-needed.ejs
@@ -1,1 +1,3 @@
-<div><%- include('/mfa-settings/external-help-needed-layout.ejs'); %></div>
+<div>
+  <%- include('../../../mfa-settings/external-help-needed-layout.ejs'); %>
+</div>

--- a/src/views/user/mfa-decision-helper/can-install-software/index.ejs
+++ b/src/views/user/mfa-decision-helper/can-install-software/index.ejs
@@ -1,5 +1,5 @@
 <div>
-  <%- include('/mfa-settings/can-install-software-layout.ejs', {
+  <%- include('../../../mfa-settings/can-install-software-layout.ejs', {
     formAction: '/users/mfa-decision-helper/can-install-software',
   }); %>
 </div>

--- a/src/views/user/mfa-decision-helper/can-install-software/smartphone-app.ejs
+++ b/src/views/user/mfa-decision-helper/can-install-software/smartphone-app.ejs
@@ -1,5 +1,5 @@
 <div>
-  <%- include('/mfa-settings/smartphone-app-layout.ejs', {
+  <%- include('../../../mfa-settings/smartphone-app-layout.ejs', {
     totpRecommendationPath: '../user/mfa-decision-helper/totp-recommendation.ejs',
   }); %>
 </div>

--- a/src/views/user/mfa-decision-helper/can-install-software/smartphone.ejs
+++ b/src/views/user/mfa-decision-helper/can-install-software/smartphone.ejs
@@ -1,5 +1,5 @@
 <div>
-  <%- include('/mfa-settings/smartphone-layout.ejs', {
+  <%- include('../../../mfa-settings/smartphone-layout.ejs', {
     formAction: '/users/mfa-decision-helper/can-install-software/smartphone',
   }); %>
 </div>

--- a/src/views/user/mfa-decision-helper/can-install-software/software.ejs
+++ b/src/views/user/mfa-decision-helper/can-install-software/software.ejs
@@ -1,5 +1,5 @@
 <div>
-  <%- include('/mfa-settings/software-layout.ejs', {
+  <%- include('../../../mfa-settings/software-layout.ejs', {
     totpRecommendationPath: '../user/mfa-decision-helper/totp-recommendation.ejs',
   }); %>
 </div>

--- a/src/views/user/mfa-decision-helper/index.ejs
+++ b/src/views/user/mfa-decision-helper/index.ejs
@@ -1,5 +1,5 @@
 <div>
-  <%- include('/mfa-settings/index-layout.ejs', {
+  <%- include('../../mfa-settings/index-layout.ejs', {
     formAction: '/users/mfa-decision-helper',
   }); %>
 </div>

--- a/src/views/user/mfa-decision-helper/passkey.ejs
+++ b/src/views/user/mfa-decision-helper/passkey.ejs
@@ -1,5 +1,5 @@
 <div>
-  <%- include('/mfa-settings/passkey-layout.ejs', {
+  <%- include('../../mfa-settings/passkey-layout.ejs', {
     notifications: notifications,
     csrfToken: csrfToken,
     verifyRegistrationAction: '/users/passkeys/verify-registration',

--- a/src/views/user/mfa-decision-helper/totp-recommendation.ejs
+++ b/src/views/user/mfa-decision-helper/totp-recommendation.ejs
@@ -1,4 +1,4 @@
-<%- include('/mfa-settings/totp-recommendation-layout.ejs', {
+<%- include('../../mfa-settings/totp-recommendation-layout.ejs', {
   description: description,
   toolTypeLabel: toolTypeLabel,
   tools: tools,

--- a/src/views/user/totp-configuration.ejs
+++ b/src/views/user/totp-configuration.ejs
@@ -1,5 +1,5 @@
 <div>
-    <%- include('/mfa-settings/totp-configuration-layout.ejs', {
+    <%- include('../mfa-settings/totp-configuration-layout.ejs', {
         nextStepTitle: "Vous pouvez dès à présent vous ProConnecter",
         totpConfigurationUrl: '/users/totp-configuration',
         cancelUrl: '/users/double-authentication-choice',


### PR DESCRIPTION
This reverts commit 3b55a315034b02cd63312aa89a512e2ff0c20ee8.

**Problem**

In `src/services/renderer.ts`, we redefine the app engine that was initially defined in `src/index.ts`, but with a different root configuration.

We were not able to make it work without defining it twice, but we would rather not keep this double definition running because we are unsure of its consequences. For instance, absolute paths may or may not work depending on where the template is called.

**Proposal**

Go back to the relative path definition.

We would rather spend time migrating all templates to Kitajs than keep twisting EJS further.