### PR TITLE
🕒 Homogenize FranceConnect last-update date formatting

### DIFF
--- a/src/controllers/main.ts
+++ b/src/controllers/main.ts
@@ -1,5 +1,4 @@
 import type { NextFunction, Request, Response } from "express";
-import moment from "moment/moment";
 import z, { ZodError } from "zod";
 import { context } from "../connectors/context";
 import { is2FACapable } from "../managers/2fa";
@@ -24,6 +23,7 @@ import {
   nameSchema,
   phoneNumberSchema,
 } from "../services/custom-zod-schemas";
+import { formatDate } from "../services/date-format";
 import { getNotificationsFromRequest } from "../services/get-notifications-from-request";
 
 const { update } = context.repository.users;
@@ -52,6 +52,10 @@ export const getPersonalInformationsController = async (
     const familyNameOptions =
       await getFamilyNameOptionsFromFranceConnectIdentity(user.id);
 
+    const franceconnectUpdatedAt = await lastFranceConnectIdentityUpdate(
+      user.id,
+    );
+
     return res.render("personal-information", {
       csrfToken: csrfToken(req),
       email: user.email,
@@ -61,7 +65,9 @@ export const getPersonalInformationsController = async (
       notifications: await getNotificationsFromRequest(req),
       pageTitle: "Informations personnelles",
       phone_number: user.phone_number,
-      franceConnect_last_update: await lastFranceConnectIdentityUpdate(user.id),
+      franceconnect_updated_at: franceconnectUpdatedAt
+        ? formatDate(franceconnectUpdatedAt)
+        : null,
       givenNameOptions,
       familyNameOptions,
     });
@@ -200,10 +206,7 @@ export const getConnectionAndAccountController = async (
       isVerifiedWithFranceConnect,
       passkeys,
       totpKeyVerifiedAt: totp_key_verified_at
-        ? moment(totp_key_verified_at)
-            .tz("Europe/Paris")
-            .locale("fr")
-            .calendar()
+        ? formatDate(totp_key_verified_at)
         : null,
       csrfToken: csrfToken(req),
       is2faCapable,

--- a/src/managers/webauthn.ts
+++ b/src/managers/webauthn.ts
@@ -16,8 +16,6 @@ import {
   type WebAuthnCredential,
 } from "@simplewebauthn/server";
 import { isEmpty } from "lodash-es";
-import moment from "moment";
-import "moment-timezone";
 import { AssertionError } from "node:assert";
 import { APPLICATION_NAME, HOST, WEBSITE_IDENTIFIER } from "../config/env";
 import {
@@ -26,6 +24,7 @@ import {
 } from "../config/errors";
 import { context } from "../connectors/context";
 import { getAuthenticatorFriendlyName } from "../connectors/github-passkey-authenticator-aaguids";
+import { formatDate } from "../services/date-format";
 import { logger } from "../services/log";
 import { disableForce2fa, is2FACapable } from "./2fa";
 
@@ -78,9 +77,9 @@ export const getUserAuthenticators = async (email: string) => {
       credential_id,
       usage_count,
       display_name: display_name || `Clé ${credential_id.substring(0, 10)}`,
-      created_at: moment(created_at).tz("Europe/Paris").locale("fr").calendar(),
+      created_at: formatDate(created_at),
       last_used_at: last_used_at
-        ? moment(last_used_at).tz("Europe/Paris").locale("fr").calendar()
+        ? formatDate(last_used_at)
         : "pas encore utilisée",
       shows_second_factor_only_label: !user_verified,
     }),

--- a/src/services/date-format.test.ts
+++ b/src/services/date-format.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { before, describe, it, mock } from "node:test";
+import { formatDate } from "./date-format";
+
+describe("formatDate", () => {
+  before(() =>
+    mock.timers.enable({
+      apis: ["Date"],
+      now: new Date("4444-04-04T04:44:44.444Z"),
+    }),
+  );
+  it("should format a date", () => {
+    const date = new Date("2022-01-01");
+    const formattedDate = formatDate(date);
+    assert.equal(formattedDate, "01/01/2022");
+  });
+  it("should format a recent date", () => {
+    const date = new Date();
+    const formattedDate = formatDate(date);
+    assert.equal(formattedDate, "Aujourd’hui à 05:44");
+  });
+  it("should format a yesterday date", () => {
+    const date = new Date("4444-04-03T04:44:44.444Z");
+    const formattedDate = formatDate(date);
+    assert.equal(formattedDate, "Hier à 05:44");
+  });
+});

--- a/src/services/date-format.ts
+++ b/src/services/date-format.ts
@@ -1,0 +1,6 @@
+import moment from "moment";
+import "moment-timezone";
+
+export const formatDate = (date: Date): string => {
+  return moment(date).tz("Europe/Paris").locale("fr").calendar();
+};

--- a/src/views/personal-information.ejs
+++ b/src/views/personal-information.ejs
@@ -10,7 +10,7 @@
 
             <p aria-hidden="true" class="fr-hint-text">Les champs notés * sont obligatoires.</p>
 
-            <% if (locals.franceConnect_last_update) { %>
+            <% if (locals.franceconnect_updated_at) { %>
             <div class="fr-select-group">
                 <label class="fr-label" for="given_name">
                     Prénom<span aria-hidden="true"> *</span>
@@ -46,7 +46,7 @@
             </div>
             <% } %>
 
-            <% if (locals.franceConnect_last_update) { %>
+            <% if (locals.franceconnect_updated_at) { %>
             <div class="fr-select-group">
                 <label class="fr-label" for="family_name">
                     Nom<span aria-hidden="true"> *</span>
@@ -122,13 +122,11 @@
 
         <h1 class="fr-h3 fr-mt-4w">Identité FranceConnect</h1>
 
-        <% if (locals.franceConnect_last_update) { %>
+        <% if (locals.franceconnect_updated_at) { %>
 
         <p>
           Vous avez utilisé votre identité FranceConnect pour pré-remplir vos informations personnelles. <br/>
-          <em>Dernière connexion FranceConnect :
-          le <%= locals.franceConnect_last_update.toLocaleString("fr-FR", { weekday: "long", year: "numeric", month: "long", day: "numeric", timeZone: "UTC" }); %>
-          à <%= locals.franceConnect_last_update.toLocaleTimeString("fr-FR"); %></em>
+          <em>Dernière connexion FranceConnect : <%= locals.franceconnect_updated_at; %></em>
         </p>
 
         <h2 class="fr-h6">Mettre à jour votre identité FranceConnect</h2>


### PR DESCRIPTION
**Problem**

The FranceConnect last-update date was formatted with `timeZone: "UTC"`,
while the time displayed right below it used the server's local timezone.

**Proposal**

Reuse Moment.js instead of the native JavaScript implementation to
reduce heterogeneity and support timezone handling.