### PR TITLE
🐛 Fix official contact code bypass flaw

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -29,6 +29,7 @@ jobs:
           - join_collectivite_territoriale_free_contact_domain
           - join_collectivite_territoriale_multiple_contact_emails
           - join_collectivite_territoriale_official_contact_domain
+          - join_collectivite_territoriale_official_contact_pending
           - join_must_confirm
           - join_org_with_rejected_moderation
           - join_org_with_trackdechets_domain

--- a/cypress/e2e/join_collectivite_territoriale_official_contact_domain/index.cy.ts
+++ b/cypress/e2e/join_collectivite_territoriale_official_contact_domain/index.cy.ts
@@ -82,6 +82,7 @@ describe("join collectivité territoriale with code send to official contact ema
     cy.contains("Continuer avec cet email").click();
 
     cy.title().should("include", "Vérifier votre email - ProConnect");
+    cy.contains("Confirmer votre adresse email").click();
 
     cy.maildevGetMessageBySubject(
       "[ProConnect] Authentifier un email sur ProConnect",

--- a/cypress/e2e/join_collectivite_territoriale_official_contact_pending/env.conf
+++ b/cypress/e2e/join_collectivite_territoriale_official_contact_pending/env.conf
@@ -1,0 +1,2 @@
+FEATURE_CONSIDER_ALL_EMAIL_DOMAINS_AS_NON_FREE=False
+TEST_CONTACT_EMAIL=magnus.the.red@new.prospero.world

--- a/cypress/e2e/join_collectivite_territoriale_official_contact_pending/fixtures.sql
+++ b/cypress/e2e/join_collectivite_territoriale_official_contact_pending/fixtures.sql
@@ -1,0 +1,103 @@
+INSERT INTO
+  users (
+    id,
+    email,
+    email_verified,
+    email_verified_at,
+    encrypted_password,
+    created_at,
+    updated_at,
+    given_name,
+    family_name,
+    phone_number,
+    job
+  )
+VALUES
+  (
+    1,
+    'god-emperor@yopmail.com',
+    true,
+    CURRENT_TIMESTAMP,
+    '$2a$10$kzY3LINL6..50Fy9shWCcuNlRfYq0ft5lS.KCcJ5PzrhlWfKK4NIO',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    'God',
+    'Emperor',
+    '9999999999',
+    'God Emperor'
+  );
+
+INSERT INTO
+  organizations (id, cached_libelle, siret, created_at, updated_at)
+VALUES
+  (
+    1,
+    'Ministere des armees ',
+    '11009001600053',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+  ),
+  (
+    2,
+    'Commune de lamalou-les-bains - Mairie',
+    '21340126800130',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+  );
+
+INSERT INTO
+  users_organizations (
+    user_id,
+    organization_id,
+    is_external,
+    verification_type,
+    has_been_greeted
+  )
+VALUES
+  (1, 1, false, 'domain', true);
+
+INSERT INTO
+  email_domains (
+    organization_id,
+    domain,
+    verification_type,
+    verified_at
+  )
+VALUES
+  (
+    1,
+    'prospero.world',
+    'verified',
+    CURRENT_TIMESTAMP
+  );
+
+INSERT INTO
+  oidc_clients (
+    client_name,
+    client_id,
+    client_secret,
+    redirect_uris,
+    post_logout_redirect_uris,
+    scope,
+    client_uri,
+    client_description,
+    userinfo_signed_response_alg,
+    id_token_signed_response_alg,
+    authorization_signed_response_alg,
+    introspection_signed_response_alg
+  )
+VALUES
+  (
+    'Oidc Test Client',
+    'standard_client_id',
+    'standard_client_secret',
+    ARRAY['http://localhost:4000/login-callback'],
+    ARRAY['http://localhost:4000/'],
+    'openid email profile organization',
+    'http://localhost:4000/',
+    'ProConnect test client. More info: https://github.com/proconnect-gouv/proconnect-test-client.',
+    null,
+    null,
+    null,
+    null
+  );

--- a/cypress/e2e/join_collectivite_territoriale_official_contact_pending/index.cy.ts
+++ b/cypress/e2e/join_collectivite_territoriale_official_contact_pending/index.cy.ts
@@ -1,0 +1,35 @@
+//
+
+describe("pending code sent to official contact email", () => {
+  beforeEach(cy.seed);
+
+  it("should not authorize a user to use the pending organization link", function () {
+    cy.visit("http://localhost:4000");
+
+    cy.get("button.proconnect-button").click();
+
+    cy.login("god-emperor@yopmail.com");
+
+    cy.contains('"email": "god-emperor@yopmail.com"');
+    cy.contains('"siret": "11009001600053"');
+
+    cy.visit("/users/join-organization");
+
+    cy.title().should("include", "Rejoindre une organisation - ProConnect");
+    cy.contains("SIRET de l’organisation que vous représentez").click();
+    cy.focused().clear().type("21340126800130");
+    cy.contains("Enregistrer").click();
+
+    cy.title().should("include", "Confirmer le rattachement - ProConnect");
+    cy.contains("Continuer avec cet email").click();
+
+    cy.title().should("include", "Vérifier votre email - ProConnect");
+
+    cy.visit("http://localhost:4000");
+
+    cy.get("button.proconnect-button").click();
+
+    cy.title().should("include", "Vérifier votre email - ProConnect");
+    cy.contains("Confirmer votre adresse email").click();
+  });
+});

--- a/src/services/oidc-account-adapter.ts
+++ b/src/services/oidc-account-adapter.ts
@@ -82,7 +82,9 @@ export const findAccount: FindAccount = async (_ctx, sub) => {
       }
 
       const organization = organizations.find(
-        ({ id }) => id === selectedOrganizationId,
+        ({ id, needs_official_contact_email_verification }) =>
+          id === selectedOrganizationId &&
+          !needs_official_contact_email_verification,
       );
 
       if (isEmpty(organization)) {

--- a/src/services/oidc-policy.ts
+++ b/src/services/oidc-policy.ts
@@ -1,6 +1,10 @@
 import { to } from "await-to-js";
+import { isEmpty } from "lodash-es";
 import { interactionPolicy } from "oidc-provider";
-import { getOrganizationById } from "../managers/organization/main";
+import {
+  getOrganizationById,
+  getOrganizationsByUserId,
+} from "../managers/organization/main";
 import { getSelectedOrganizationId } from "../repositories/redis/selected-organization";
 
 //
@@ -26,6 +30,17 @@ policy.add(
         );
 
         if (!selectedOrganizationId) {
+          return Check.REQUEST_PROMPT;
+        }
+
+        const userOrganizations = await getOrganizationsByUserId(user_id);
+        const organization = userOrganizations.find(
+          ({ id, needs_official_contact_email_verification }) =>
+            id === selectedOrganizationId &&
+            !needs_official_contact_email_verification,
+        );
+
+        if (isEmpty(organization)) {
           return Check.REQUEST_PROMPT;
         }
 


### PR DESCRIPTION
**Problem**

When a user has an active session, they can initiate the process to send a code to an organization's official contact email.

However, while this process is still ongoing, the user can reuse an active `oidc-provider` session to connect with the organization they do not belong to yet.

**Proposal**

Check whether an official contact email verification process is ongoing within the `oidc-provider` connectors before considering the user as part of the organization.