### PR TITLE
✨ Fix mailto encoding and prefill subject/body in DeleteAccessKey email

### DIFF
--- a/packages/email/src/DeleteAccessKey.test.tsx.snapshot
+++ b/packages/email/src/DeleteAccessKey.test.tsx.snapshot
@@ -149,7 +149,7 @@ exports[`DeleteAccessKey > should render 1`] = `
                                   >
                                     Une clé d'accès a été supprimée de votre
                                     compte.<br /><br /><a
-                                      href="mailto:support+identite@proconnect.gouv.fr?subject=Erreur+-+Delete+Access+Key"
+                                      href="mailto:support+identite@proconnect.gouv.fr?subject=Suppression%20non%20reconnue%20d'une%20cl%C3%A9%20d'acc%C3%A8s%20sur%20mon%20compte%20ProConnect&body=Bonjour%2C%0A%0AJ'ai%20re%C3%A7u%20une%20notification%20m'informant%20qu'une%20cl%C3%A9%20d'acc%C3%A8s%20a%20%C3%A9t%C3%A9%20supprim%C3%A9e%20de%20mon%20compte%20ProConnect.%0A%0AJe%20ne%20suis%20pas%20%C3%A0%20l'origine%20de%20cette%20suppression.%20Je%20souhaite%20signaler%20une%20activit%C3%A9%20suspecte%20sur%20mon%20compte%20et%20v%C3%A9rifier%20qu'aucun%20acc%C3%A8s%20non%20autoris%C3%A9%20n'a%20eu%20lieu.%0A%0ACordialement%2C%0A%0AMarie%20Dupont"
                                       style="
                                         color: rgb(0, 0, 145);
                                         font-family:

--- a/packages/email/src/DeleteAccessKey.tsx
+++ b/packages/email/src/DeleteAccessKey.tsx
@@ -7,10 +7,13 @@ import { Link, Text } from "./components/index.js";
 
 export default function DeleteAccessKey(props: Props) {
   const { family_name, given_name, support_email } = props;
-  const mailtoParams = new URLSearchParams({
-    subject: "Erreur - Delete Access Key",
-  });
-  const mailtoHref = `mailto:${support_email}?${mailtoParams.toString()}`;
+  const subject = encodeURIComponent(
+    "Suppression non reconnue d'une clé d'accès sur mon compte ProConnect",
+  );
+  const body = encodeURIComponent(
+    `Bonjour,\n\nJ'ai reçu une notification m'informant qu'une clé d'accès a été supprimée de mon compte ProConnect.\n\nJe ne suis pas à l'origine de cette suppression. Je souhaite signaler une activité suspecte sur mon compte et vérifier qu'aucun accès non autorisé n'a eu lieu.\n\nCordialement,\n\n${given_name} ${family_name}`,
+  );
+  const mailtoHref = `mailto:${support_email}?subject=${subject}&body=${body}`;
   return (
     <Layout>
       <Text safe>


### PR DESCRIPTION
- Replace URLSearchParams with encodeURIComponent to fix literal "+" characters appearing instead of spaces in the mailto subject
- Add a clearer, French subject line for support triage
- Prefill the email body with context (user's name and issue description) to reduce back-and-forth with support