### PR TITLE
✨ send confirmation email on password reset

### DIFF
--- a/.changeset/password-changed-email.md
+++ b/.changeset/password-changed-email.md
@@ -1,0 +1,6 @@
+---
+"@proconnect-gouv/proconnect.email": minor
+"proconnect-identite": patch
+---
+
+Send confirmation email when a user's password has been reset

--- a/cypress/e2e/reset_password/index.cy.ts
+++ b/cypress/e2e/reset_password/index.cy.ts
@@ -56,6 +56,13 @@ describe("reset password", () => {
 
     cy.title().should("include", "S'inscrire ou se connecter - ProConnect");
     cy.contains("Votre mot de passe a été mis à jour.");
+
+    cy.maildevGetMessageBySubject(
+      "Votre mot de passe ProConnect a été modifié",
+    ).then((email) => {
+      cy.maildevDeleteMessageById(email.id);
+    });
+
     cy.contains("Continuer").click();
 
     cy.title().should("include", "Accéder au compte - ProConnect");

--- a/packages/email/src/PasswordChanged.stories.tsx
+++ b/packages/email/src/PasswordChanged.stories.tsx
@@ -1,0 +1,15 @@
+//
+
+import type { ComponentAnnotations, Renderer } from "@storybook/csf";
+import PasswordChanged, { type Props } from "./PasswordChanged.js";
+
+//
+
+export default {
+  title: "Password Changed",
+  render: PasswordChanged,
+  args: {
+    given_name: "Marie",
+    family_name: "Dupont",
+  } as Props,
+} as ComponentAnnotations<Renderer, Props>;

--- a/packages/email/src/PasswordChanged.test.tsx
+++ b/packages/email/src/PasswordChanged.test.tsx
@@ -1,0 +1,20 @@
+//
+
+import { describe, it } from "node:test";
+import { format } from "prettier";
+import PasswordChanged, { type Props } from "./PasswordChanged.js";
+import storyConfig from "./PasswordChanged.stories.js";
+import "./test-utils.js";
+
+//
+
+describe("PasswordChanged", () => {
+  it("should render", async (t) => {
+    const props = storyConfig.args as Props;
+    const rendered = (<PasswordChanged {...props} />).toString();
+    const formatted = await format(rendered, { parser: "html" });
+    t.assert.snapshot(formatted);
+  });
+});
+
+//

--- a/packages/email/src/PasswordChanged.test.tsx.snapshot
+++ b/packages/email/src/PasswordChanged.test.tsx.snapshot
@@ -1,0 +1,233 @@
+exports[`PasswordChanged > should render 1`] = `
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body style="background-color: #fafafa; padding-top: 32px">
+    <table
+      width="100%"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      bgcolor="#FAFAFA"
+    >
+      <tr>
+        <td align="center" valign="top">
+          <table
+            align="center"
+            width="800"
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+            style="max-width: 800px; width: 100%"
+          >
+            <tbody>
+              <tr>
+                <td>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="font-size: 64px; line-height: 64px"
+                  >
+                    <tbody>
+                      <tr>
+                        <td> </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style=""
+                  >
+                    <tbody>
+                      <tr>
+                        <td align="center">
+                          <img
+                            src="https://identite.proconnect.gouv.fr/dist/mail-proconnect.png"
+                            alt="ProConnect"
+                            height="73"
+                            width="193"
+                          />
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="font-size: 64px; line-height: 64px"
+                  >
+                    <tbody>
+                      <tr>
+                        <td> </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    bgcolor="#FFFFFF"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="box-shadow: 0px 2px 6px 0px rgba(0, 0, 18, 0.16)"
+                  >
+                    <tbody>
+                      <tr>
+                        <td>
+                          <table
+                            align="center"
+                            width="100%"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 64px; line-height: 64px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td> </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table
+                            align="center"
+                            width="600"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="max-width: 600px; width: 100%; padding: 24px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="
+                                      color: #000;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-weight: 400;
+                                      line-height: 24px;
+                                      margin: 0;
+                                    "
+                                  >
+                                    Bonjour Marie Dupont,
+                                  </p>
+                                  <br />
+                                  <p
+                                    style="
+                                      color: #000;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-weight: 400;
+                                      line-height: 24px;
+                                      margin: 0;
+                                    "
+                                  >
+                                    Le mot de passe de votre compte ProConnect
+                                    vient d'être modifié.<br />Si vous n'êtes
+                                    pas à l'origine de cette action,
+                                    contactez-nous immédiatement.
+                                  </p>
+                                  <p
+                                    style="
+                                      color: #000;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-weight: 400;
+                                      line-height: 24px;
+                                      margin: 0;
+                                      margin-top: 16px;
+                                    "
+                                  >
+                                    Cordialement,<br />L'équipe ProConnect
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table
+                            align="center"
+                            width="100%"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 64px; line-height: 64px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td> </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="font-size: 64px; line-height: 64px"
+                  >
+                    <tbody>
+                      <tr>
+                        <td> </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <table
+            align="center"
+            width="100%"
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+            style="font-size: 64px; line-height: 64px"
+          >
+            <tbody>
+              <tr>
+                <td> </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+
+`;

--- a/packages/email/src/PasswordChanged.tsx
+++ b/packages/email/src/PasswordChanged.tsx
@@ -1,0 +1,31 @@
+//
+
+import { Layout } from "./_layout.js";
+import { Text } from "./components/index.js";
+
+//
+
+export default function PasswordChanged(props: Props) {
+  const { given_name, family_name } = props;
+  return (
+    <Layout>
+      <Text safe>
+        Bonjour {given_name} {family_name},
+      </Text>
+      <br />
+      <Text>
+        Le mot de passe de votre compte ProConnect vient d'être modifié.
+        <br />
+        Si vous n'êtes pas à l'origine de cette action, contactez-nous
+        immédiatement.
+      </Text>
+    </Layout>
+  );
+}
+
+//
+
+export type Props = {
+  given_name: string;
+  family_name: string;
+};

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -10,6 +10,7 @@ export { default as DeleteFreeTotpMail } from "./DeleteFreeTotpMail.js";
 export { default as MagicLink } from "./MagicLink.js";
 export { default as OfficialContactEmailVerification } from "./OfficialContactEmailVerification.js";
 export { default as OtpEmail } from "./OtpEmail.js";
+export { default as PasswordChanged } from "./PasswordChanged.js";
 export { default as ResetPassword } from "./ResetPassword.js";
 export { default as UpdatePersonalDataMail } from "./UpdatePersonalDataMail.js";
 export { default as VerifyEmail } from "./VerifyEmail.js";

--- a/src/managers/user.ts
+++ b/src/managers/user.ts
@@ -14,6 +14,7 @@ import {
   DeleteAccount,
   DeleteFreeTotpMail,
   MagicLink,
+  PasswordChanged,
   ResetPassword,
   UpdatePersonalDataMail,
   VerifyEmail,
@@ -551,13 +552,25 @@ export const changePassword = async (
 
   const hashedPassword = await hashPassword(password);
 
-  return await update(user.id, {
+  const result = await update(user.id, {
     encrypted_password: hashedPassword,
     email_verified: true,
     email_verified_at: new Date(),
     reset_password_token: null,
     reset_password_sent_at: null,
   });
+
+  await sendMail({
+    to: [user.email],
+    subject: "Votre mot de passe ProConnect a été modifié",
+    html: PasswordChanged({
+      given_name: user.given_name ?? "",
+      family_name: user.family_name ?? "",
+    }).toString(),
+    tag: "password-changed",
+  });
+
+  return result;
 };
 
 export const updatePersonalInformationsForRegistration = async (


### PR DESCRIPTION
**Problem**
Users who reset their password receive no signal that it happened, making a malicious reset harder to notice.

**Proposal**
Add PasswordChanged email template (following the existing Delete2faProtection pattern), send it from changePassword() in managers/user.ts right after the password hash is persisted, and cover it in the reset_password e2e test.