### PR TITLE
✨ send confirmation email when a user quits an organization

### DIFF
--- a/.changeset/quit-organization-email.md
+++ b/.changeset/quit-organization-email.md
@@ -1,0 +1,6 @@
+---
+"@proconnect-gouv/proconnect.email": minor
+"proconnect-identite": patch
+---
+
+Send confirmation email when a user quits an organization

--- a/cypress/e2e/quit-organization/index.cy.ts
+++ b/cypress/e2e/quit-organization/index.cy.ts
@@ -18,6 +18,12 @@ describe("quit the organization", () => {
     ).click();
 
     cy.contains("Vous ne faites désormais plus partie de cette organisation.");
+
+    cy.maildevGetMessageBySubject(
+      "Vous avez quitté une organisation sur ProConnect",
+    ).then((email) => {
+      cy.maildevDeleteMessageById(email.id);
+    });
   });
 
   it("quit my last organization and get redirected to join page", function () {

--- a/packages/email/src/QuitOrganization.stories.tsx
+++ b/packages/email/src/QuitOrganization.stories.tsx
@@ -1,0 +1,16 @@
+//
+
+import type { ComponentAnnotations, Renderer } from "@storybook/csf";
+import QuitOrganization, { type Props } from "./QuitOrganization.js";
+
+//
+
+export default {
+  title: "Quit Organization",
+  render: QuitOrganization,
+  args: {
+    given_name: "Marie",
+    family_name: "Dupont",
+    organization_label: "Ministère de la Culture",
+  } as Props,
+} as ComponentAnnotations<Renderer, Props>;

--- a/packages/email/src/QuitOrganization.test.tsx
+++ b/packages/email/src/QuitOrganization.test.tsx
@@ -1,0 +1,20 @@
+//
+
+import { describe, it } from "node:test";
+import { format } from "prettier";
+import QuitOrganization, { type Props } from "./QuitOrganization.js";
+import storyConfig from "./QuitOrganization.stories.js";
+import "./test-utils.js";
+
+//
+
+describe("QuitOrganization", () => {
+  it("should render", async (t) => {
+    const props = storyConfig.args as Props;
+    const rendered = (<QuitOrganization {...props} />).toString();
+    const formatted = await format(rendered, { parser: "html" });
+    t.assert.snapshot(formatted);
+  });
+});
+
+//

--- a/packages/email/src/QuitOrganization.test.tsx.snapshot
+++ b/packages/email/src/QuitOrganization.test.tsx.snapshot
@@ -1,0 +1,234 @@
+exports[`QuitOrganization > should render 1`] = `
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body style="background-color: #fafafa; padding-top: 32px">
+    <table
+      width="100%"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      bgcolor="#FAFAFA"
+    >
+      <tr>
+        <td align="center" valign="top">
+          <table
+            align="center"
+            width="800"
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+            style="max-width: 800px; width: 100%"
+          >
+            <tbody>
+              <tr>
+                <td>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="font-size: 64px; line-height: 64px"
+                  >
+                    <tbody>
+                      <tr>
+                        <td> </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style=""
+                  >
+                    <tbody>
+                      <tr>
+                        <td align="center">
+                          <img
+                            src="https://identite.proconnect.gouv.fr/dist/mail-proconnect.png"
+                            alt="ProConnect"
+                            height="73"
+                            width="193"
+                          />
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="font-size: 64px; line-height: 64px"
+                  >
+                    <tbody>
+                      <tr>
+                        <td> </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    bgcolor="#FFFFFF"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="box-shadow: 0px 2px 6px 0px rgba(0, 0, 18, 0.16)"
+                  >
+                    <tbody>
+                      <tr>
+                        <td>
+                          <table
+                            align="center"
+                            width="100%"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 64px; line-height: 64px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td> </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table
+                            align="center"
+                            width="600"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="max-width: 600px; width: 100%; padding: 24px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <p
+                                    style="
+                                      color: #000;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-weight: 400;
+                                      line-height: 24px;
+                                      margin: 0;
+                                    "
+                                  >
+                                    Bonjour Marie Dupont,
+                                  </p>
+                                  <br />
+                                  <p
+                                    style="
+                                      color: #000;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-weight: 400;
+                                      line-height: 24px;
+                                      margin: 0;
+                                    "
+                                  >
+                                    Vous avez quitté l&#39;organisation
+                                    Ministère de la Culture sur
+                                    ProConnect.&lt;br/>Si vous n&#39;êtes pas à
+                                    l&#39;origine de cette action,
+                                    contactez-nous immédiatement.
+                                  </p>
+                                  <p
+                                    style="
+                                      color: #000;
+                                      font-family:
+                                        &quot;Source Sans Pro&quot;, Verdana,
+                                        Geneva, Arial, sans-serif;
+                                      font-size: 16px;
+                                      font-weight: 400;
+                                      line-height: 24px;
+                                      margin: 0;
+                                      margin-top: 16px;
+                                    "
+                                  >
+                                    Cordialement,<br />L'équipe ProConnect
+                                  </p>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table
+                            align="center"
+                            width="100%"
+                            border="0"
+                            cellpadding="0"
+                            cellspacing="0"
+                            role="presentation"
+                            style="font-size: 64px; line-height: 64px"
+                          >
+                            <tbody>
+                              <tr>
+                                <td> </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <table
+                    align="center"
+                    width="100%"
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    role="presentation"
+                    style="font-size: 64px; line-height: 64px"
+                  >
+                    <tbody>
+                      <tr>
+                        <td> </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <table
+            align="center"
+            width="100%"
+            border="0"
+            cellpadding="0"
+            cellspacing="0"
+            role="presentation"
+            style="font-size: 64px; line-height: 64px"
+          >
+            <tbody>
+              <tr>
+                <td> </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+
+`;

--- a/packages/email/src/QuitOrganization.tsx
+++ b/packages/email/src/QuitOrganization.tsx
@@ -1,0 +1,32 @@
+//
+
+import { Layout } from "./_layout.js";
+import { Text } from "./components/index.js";
+
+//
+
+export default function QuitOrganization(props: Props) {
+  const { given_name, family_name, organization_label } = props;
+  return (
+    <Layout>
+      <Text safe>
+        Bonjour {given_name} {family_name},
+      </Text>
+      <br />
+      <Text safe>
+        Vous avez quitté l'organisation {organization_label} sur ProConnect.
+        <br />
+        Si vous n'êtes pas à l'origine de cette action, contactez-nous
+        immédiatement.
+      </Text>
+    </Layout>
+  );
+}
+
+//
+
+export type Props = {
+  given_name: string;
+  family_name: string;
+  organization_label: string;
+};

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -10,6 +10,7 @@ export { default as DeleteFreeTotpMail } from "./DeleteFreeTotpMail.js";
 export { default as MagicLink } from "./MagicLink.js";
 export { default as OfficialContactEmailVerification } from "./OfficialContactEmailVerification.js";
 export { default as OtpEmail } from "./OtpEmail.js";
+export { default as QuitOrganization } from "./QuitOrganization.js";
 export { default as ResetPassword } from "./ResetPassword.js";
 export { default as UpdatePersonalDataMail } from "./UpdatePersonalDataMail.js";
 export { default as VerifyEmail } from "./VerifyEmail.js";

--- a/src/managers/organization/main.ts
+++ b/src/managers/organization/main.ts
@@ -1,8 +1,10 @@
+import { QuitOrganization } from "@proconnect-gouv/proconnect.email";
 import { NotFoundError } from "@proconnect-gouv/proconnect.identite/errors";
 import { markDomainAsVerifiedFactory } from "@proconnect-gouv/proconnect.identite/managers/organization";
 import type { Organization } from "@proconnect-gouv/proconnect.identite/types";
 import { isEmpty } from "lodash-es";
 import { context } from "../../connectors/context";
+import { sendMail } from "../../connectors/mail";
 import { setSelectedOrganizationId } from "../../repositories/redis/selected-organization";
 
 const {
@@ -12,6 +14,8 @@ const {
   findPendingByUserId,
   deleteUserOrganization,
 } = context.repository.organizations;
+
+const { getById: getUserById } = context.repository.users;
 
 export const getOrganizationsByUserId = findByUserId;
 export const getOrganizationById = findOrganizationById;
@@ -34,6 +38,12 @@ export const quitOrganization = async ({
   user_id: number;
   organization_id: number;
 }) => {
+  const organization = await findOrganizationById(organization_id);
+
+  if (isEmpty(organization)) {
+    throw new NotFoundError();
+  }
+
   const hasBeenRemoved = await deleteUserOrganization({
     user_id,
     organization_id,
@@ -42,6 +52,19 @@ export const quitOrganization = async ({
   if (!hasBeenRemoved) {
     throw new NotFoundError();
   }
+
+  const { given_name, family_name, email } = await getUserById(user_id);
+
+  await sendMail({
+    to: [email],
+    subject: "Vous avez quitté une organisation sur ProConnect",
+    html: QuitOrganization({
+      given_name: given_name ?? "",
+      family_name: family_name ?? "",
+      organization_label: organization.cached_libelle || organization.siret,
+    }).toString(),
+    tag: "quit-organization",
+  });
 
   return true;
 };


### PR DESCRIPTION
**Problem**
Users who leave an organization get no notification, so an unintended or malicious quit can go unnoticed.

**Proposal**
Add QuitOrganization email template (same pattern as PasswordChanged/Delete2faProtection), send it from quitOrganization() in managers/organization/main.ts right after the user-organization link is removed, and cover it in the quit-organization e2e test.