### PR TITLE
🚧 Restrict the Hono server to its mount path

### DIFF
--- a/packages/testing/src/api/routes/oidc.franceconnect.gouv.fr/index.ts
+++ b/packages/testing/src/api/routes/oidc.franceconnect.gouv.fr/index.ts
@@ -83,12 +83,8 @@ export const TestingOidcFranceConnectRouter = new Hono<{
       const { client_id, redirect_uri, state, nonce } = req.valid("query");
       const codeValue = `_${Date.now()}`;
       CODE_MAP.set(codeValue, { client_id, nonce, redirect_uri, state });
-      const basePath = new URL(req.url).pathname
-        .split("/")
-        .slice(0, -3)
-        .join("/");
 
-      return redirect(`${basePath}/interaction/${codeValue}/login`);
+      return redirect(`../../interaction/${codeValue}/login`);
     },
   )
   .get(

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,8 @@ app.use("/oauth", oidcProvider.callback());
 
 if (DEPLOY_ENV === "localhost") {
   app.use(
-    createTestingHandler("/___testing___", {
+    "/___testing___",
+    createTestingHandler("/", {
       ISSUER: FRANCECONNECT_ISSUER,
       log: logger.warn,
     }),


### PR DESCRIPTION
**Problem**

Hono uses the base path `/___testing___` for its routes, but still listens on `/`.

As a result, in the development environment, Hono handles 404 errors instead of letting the Express server handle them as expected.

**Proposal**

Mount the Hono server under `/___testing___` so it only handles the routes it is responsible for.