### PR TITLE
🚦 Improve rate limit handling

### DIFF
--- a/cypress/e2e/rate_limit_by_ip/fixtures.sql
+++ b/cypress/e2e/rate_limit_by_ip/fixtures.sql
@@ -25,7 +25,42 @@ VALUES
     'Limit',
     '0123456789',
     'Rate limit test user'
+  ),
+  (
+    2,
+    'rate-limit+user2@yopmail.com',
+    true,
+    CURRENT_TIMESTAMP,
+    '$2a$10$kzY3LINL6..50Fy9shWCcuNlRfYq0ft5lS.KCcJ5PzrhlWfKK4NIO',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    'Rate',
+    'Limit',
+    '0123456789',
+    'Rate limit test user'
   );
+
+INSERT INTO
+  organizations (id, cached_libelle, siret, created_at, updated_at)
+VALUES
+  (
+    1,
+    'Commune de lamalou-les-bains - Mairie',
+    '21340126800130',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+  );
+
+INSERT INTO
+  users_organizations (
+    user_id,
+    organization_id,
+    is_external,
+    verification_type,
+    has_been_greeted
+  )
+VALUES
+  (1, 1, false, 'domain', true);
 
 INSERT INTO
   oidc_clients (

--- a/cypress/e2e/rate_limit_by_ip/index.cy.ts
+++ b/cypress/e2e/rate_limit_by_ip/index.cy.ts
@@ -2,20 +2,53 @@
 
 describe("trigger rate limiting by ip", () => {
   before(cy.seed);
+  beforeEach(() => {
+    // Clear rate-limiter credits
+    cy.exec(
+      "docker compose exec redis redis-cli --scan --pattern 'rate-limiter:*' | xargs -r docker compose exec redis redis-cli DEL",
+    );
+  });
 
-  it("should trigger ip rate limiting", function () {
+  it("should trigger ip rate limiting when hitting 51 pages after a successful login", function () {
     cy.visit("http://localhost:4000");
 
     cy.get("button.proconnect-button").click();
 
     cy.login("rate-limit+user@yopmail.com");
 
-    for (let i = 0; i <= 60; i++) {
-      cy.visit("/users/start-sign-in", { failOnStatusCode: false });
+    cy.title().should("equal", "standard-client - ProConnect");
+    cy.contains("standard-client");
+
+    // we already consumed 9 rate limiter credits during the login process
+    for (let i = 1; i <= 60 - 9; i++) {
+      cy.visit("/", { failOnStatusCode: false });
+      cy.contains("Votre compte ProConnect");
     }
 
+    cy.visit("/", { failOnStatusCode: false });
     cy.contains("Too Many Requests");
+    cy.contains(
+      "Merci de ne pas retenter de connexion dans l’immédiat et de réessayer dans une quinzaine de minutes.",
+    );
 
+    cy.contains("Retour à l’accueil").click();
+  });
+
+  it("should trigger ip rate limiting when a login is ongoing", function () {
+    cy.visit("http://localhost:4000");
+
+    cy.get("button.proconnect-button").click();
+
+    cy.login("rate-limit+user2@yopmail.com");
+
+    // we already consumed 8 rate limiter credits during the login process
+    for (let i = 1; i <= 60 - 8; i++) {
+      cy.visit("/");
+      cy.contains("Votre compte ProConnect");
+    }
+
+    cy.visit("/", { failOnStatusCode: false });
+    cy.contains("Too Many Requests");
     cy.contains(
       "Merci de ne pas retenter de connexion dans l’immédiat et de réessayer dans une quinzaine de minutes.",
     );
@@ -24,5 +57,45 @@ describe("trigger rate limiting by ip", () => {
 
     cy.url().should("include", "error=server_error");
     cy.url().should("include", "error_description=Too%20many%20requests");
+  });
+
+  it("should trigger IP rate limiting by hitting 404 errors", function () {
+    for (let i = 1; i <= 60; i++) {
+      cy.visit("http://localhost:3000/random", { failOnStatusCode: false });
+      cy.contains("Page non trouvée");
+    }
+
+    cy.visit("http://localhost:3000/random", { failOnStatusCode: false });
+    cy.contains("Too Many Requests");
+    cy.contains(
+      "Merci de ne pas retenter de connexion dans l’immédiat et de réessayer dans une quinzaine de minutes.",
+    );
+
+    cy.contains("Retour à l’accueil").click();
+  });
+
+  it("should trigger IP rate limiting by hitting 404 errors under /oauth", function () {
+    for (let i = 1; i <= 60; i++) {
+      cy.request(
+        "http://localhost:3000/oauth/.well-known/openid-configuration",
+      );
+    }
+
+    cy.request({
+      url: "http://localhost:3000/oauth/.well-known/openid-configuration",
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(429);
+    });
+  });
+
+  it("should not trigger IP rate limiting by hitting 404 errors under /api", function () {
+    for (let i = 1; i <= 100; i++) {
+      cy.visit("http://localhost:3000/api/random", { failOnStatusCode: false });
+      cy.contains("Page non trouvée");
+    }
+
+    cy.visit("http://localhost:3000/api/random", { failOnStatusCode: false });
+    cy.contains("Page non trouvée");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,10 @@ import { OidcError } from "./config/errors";
 import { createOidcProvider } from "./config/oidc-provider";
 import { getNewRedisClient } from "./connectors/redis";
 import { trustedBrowserMiddleware } from "./managers/browser-authentication";
+import {
+  apiRateLimiterMiddleware,
+  rateLimiterMiddleware,
+} from "./middlewares/rate-limiter";
 import { apiRouter } from "./routers/api";
 import { interactionRouter } from "./routers/interaction";
 import { mainRouter } from "./routers/main";
@@ -155,6 +159,21 @@ app.get("/favicon.ico", function (_req, res, _next) {
   });
 });
 
+app.use((req, res, next) => {
+  if (req.path.startsWith("/api/")) {
+    return apiRateLimiterMiddleware(req, res, next);
+  }
+
+  return rateLimiterMiddleware(req, res, (err) => {
+    if (err) {
+      // If an error occurs, add the EJS layout middleware to render a properly formatted 429 error page
+      return ejsLayoutMiddlewareFactory(app)(req, res, () => next(err));
+    }
+
+    return next();
+  });
+});
+
 app.use("/", mainRouter(app));
 app.use(
   "/interaction",
@@ -206,6 +225,19 @@ app.use(function errorHandler(
   _next: NextFunction,
 ) {
   logger.error(inspect(err, { depth: 3 }));
+
+  if (req.path.startsWith("/api/")) {
+    if (err instanceof HttpErrors.HttpError) {
+      const statusCode = err?.statusCode || 500;
+
+      return res
+        .status(statusCode)
+        .json({ message: err.message || err["statusMessage"] });
+    }
+
+    return res.status(500).json({ message: err.message });
+  }
+
   if (err instanceof HttpErrors.HttpError) {
     if (err.statusCode === 404) {
       return res.status(404).render("not-found-error", {

--- a/src/routers/api.ts
+++ b/src/routers/api.ts
@@ -1,8 +1,5 @@
-import type { NextFunction, Request, Response } from "express";
 import { Router, urlencoded } from "express";
-import { HttpError } from "http-errors";
 import nocache from "nocache";
-import { inspect } from "node:util";
 import {
   getOrganizationInfoController,
   getPingApiAnnuaireEducationNationaleController,
@@ -18,8 +15,6 @@ import {
   getGenerateAuthenticationOptionsForSecondFactorController,
   getGenerateRegistrationOptionsController,
 } from "../controllers/webauthn";
-import { apiRateLimiterMiddleware } from "../middlewares/rate-limiter";
-import { logger } from "../services/log";
 
 export const apiRouter = () => {
   const apiRouter = Router();
@@ -27,8 +22,6 @@ export const apiRouter = () => {
   apiRouter.use(nocache());
 
   apiRouter.use(urlencoded({ extended: false }));
-
-  apiRouter.use(apiRateLimiterMiddleware);
 
   apiRouter.get("/insee/ping", getPingApiInseeController);
   apiRouter.get("/debounce/ping", getPingApiDebounceController);
@@ -62,23 +55,6 @@ export const apiRouter = () => {
   apiRouter.get(
     "/webauthn/generate-authentication-options-for-second-factor",
     getGenerateAuthenticationOptionsForSecondFactorController,
-  );
-
-  apiRouter.use(
-    async (
-      err: HttpError,
-      _req: Request,
-      res: Response,
-      _next: NextFunction,
-    ) => {
-      logger.error(inspect(err, { depth: 3 }));
-
-      const statusCode = err.statusCode || 500;
-
-      return res
-        .status(statusCode)
-        .json({ message: err.message || err["statusMessage"] });
-    },
   );
 
   return apiRouter;

--- a/src/routers/interaction.ts
+++ b/src/routers/interaction.ts
@@ -7,7 +7,6 @@ import {
   interactionStartControllerFactory,
 } from "../controllers/interaction";
 import { userSignInRequirementsGuardMiddleware } from "../middlewares/navigation-guards";
-import { rateLimiterMiddleware } from "../middlewares/rate-limiter";
 
 export const interactionRouter = (oidcProvider: Provider) => {
   const interactionRouter = Router();
@@ -15,8 +14,6 @@ export const interactionRouter = (oidcProvider: Provider) => {
   interactionRouter.use(nocache());
 
   interactionRouter.use(urlencoded({ extended: false }));
-
-  interactionRouter.use(rateLimiterMiddleware);
 
   interactionRouter.get(
     "/:grant",

--- a/src/routers/main.ts
+++ b/src/routers/main.ts
@@ -37,10 +37,7 @@ import {
   userCanAccessAdminGuardMiddleware,
   userCanAccessAppGuardMiddleware,
 } from "../middlewares/navigation-guards";
-import {
-  authenticatorRateLimiterMiddleware,
-  rateLimiterMiddleware,
-} from "../middlewares/rate-limiter";
+import { authenticatorRateLimiterMiddleware } from "../middlewares/rate-limiter";
 import { ejsLayoutMiddlewareFactory } from "../services/renderer";
 
 export const mainRouter = (app: Express) => {
@@ -51,7 +48,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     getConnectionAndAccountController,
@@ -62,7 +58,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     getDoubleAuthenticationController,
@@ -73,7 +68,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     getIsTotpAppInstalledController,
   );
@@ -83,7 +77,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     getMfaDecisionHelperController,
@@ -94,7 +87,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     getMfaDecisionHelperPasskeyController,
@@ -105,7 +97,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     getMfaDecisionHelperCanInstallSoftwareController,
@@ -116,7 +107,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     getMfaDecisionHelperCanInstallSoftwareSoftwareController,
@@ -127,7 +117,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     getMfaDecisionHelperCanInstallSoftwareSmartphoneController,
@@ -138,7 +127,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     getMfaDecisionHelperCanInstallSoftwareSmartphoneAppController,
@@ -149,7 +137,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     getMfaDecisionHelperCanInstallSoftwareExternalHelpNeededController,
@@ -160,7 +147,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     getTotpConfigurationController,
@@ -171,7 +157,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     authenticatorRateLimiterMiddleware,
     csrfProtectionMiddleware,
@@ -183,7 +168,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     postDeleteTotpConfigurationController,
@@ -194,7 +178,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     postVerifyRegistrationControllerFactory(
@@ -208,7 +191,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     deletePasskeyController,
@@ -219,7 +201,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAdminGuardMiddleware,
     csrfProtectionMiddleware,
     postSetForce2faController,
@@ -230,7 +211,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAppGuardMiddleware,
     csrfProtectionMiddleware,
     getPersonalInformationsController,
@@ -241,7 +221,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAppGuardMiddleware,
     csrfProtectionMiddleware,
     postPersonalInformationsController,
@@ -252,7 +231,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAppGuardMiddleware,
     csrfProtectionMiddleware,
     postDisconnectFranceConnectController,
@@ -263,7 +241,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAppGuardMiddleware,
     csrfProtectionMiddleware,
     getManageOrganizationsController,
@@ -274,7 +251,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     userCanAccessAppGuardMiddleware,
     getHomeController,
   );
@@ -284,7 +260,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     getConditionsGeneralesDUtilisationController,
   );
 
@@ -293,7 +268,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     getPolitiqueDeConfidentialiteController,
   );
 
@@ -302,7 +276,6 @@ export const mainRouter = (app: Express) => {
     nocache(),
     urlencoded({ extended: false }),
     ejsLayoutMiddlewareFactory(app, true),
-    rateLimiterMiddleware,
     getAccessibiliteController,
   );
 

--- a/src/routers/user.ts
+++ b/src/routers/user.ts
@@ -116,7 +116,6 @@ import {
   authenticatorRateLimiterMiddleware,
   officialContactEmailVerificationRateLimiterMiddleware,
   passwordRateLimiterMiddleware,
-  rateLimiterMiddleware,
   sendEmailVerificationRateLimiterMiddleware,
   sendMagicLinkRateLimiterMiddleware,
   verifyEmailRateLimiterMiddleware,
@@ -128,8 +127,6 @@ export const userRouter = () => {
   userRouter.use(nocache());
 
   userRouter.use(urlencoded({ extended: false }));
-
-  userRouter.use(rateLimiterMiddleware);
 
   userRouter.get(
     "/start-sign-in",


### PR DESCRIPTION
**Problem**

The global IP-based rate limit currently uses an opt-in policy on each router.

As a result, some routes are not rate-limited, such as `oidc-provider` routes, 404 routes, and others.

**Proposal**

Add a default global rate limit middleware over all routes except the `dist` folder, and remove the per-router configuration.