### PR TITLE
♻️ extract match_identity_to_dirigeant into its own pure module

### DIFF
--- a/packages/identite/src/managers/certification/match-identity-to-dirigeant.test.ts
+++ b/packages/identite/src/managers/certification/match-identity-to-dirigeant.test.ts
@@ -1,0 +1,62 @@
+//
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { match_identity_to_dirigeant } from "./match-identity-to-dirigeant.js";
+
+//
+
+const identity = {
+  birthcountry: null,
+  birthdate: new Date("1946-08-17"),
+  birthplace: "75001",
+  family_name: "Bernard",
+  gender: "male" as const,
+  given_name: "Stéphane",
+};
+
+describe("match_identity_to_dirigeant", () => {
+  it("returns no_candidates for an empty dirigeants list", () => {
+    assert.deepEqual(match_identity_to_dirigeant(identity, []), {
+      kind: "no_candidates",
+    });
+  });
+
+  it("returns exact_match for a score of 5", () => {
+    const result = match_identity_to_dirigeant(identity, [identity]);
+    assert.equal(result.kind, "exact_match");
+  });
+
+  it("returns close_match for a score of 4", () => {
+    const dirigeant = { ...identity, family_name: "DuMoulin" };
+    const result = match_identity_to_dirigeant(identity, [dirigeant]);
+    assert.equal(result.kind, "close_match");
+  });
+
+  it("returns close_match for a score of 3", () => {
+    const dirigeant = {
+      ...identity,
+      family_name: "DuMoulin",
+      given_name: "Robert",
+    };
+    const result = match_identity_to_dirigeant(identity, [dirigeant]);
+    assert.equal(result.kind, "close_match");
+  });
+
+  it("returns below_threshold for a score under 3", () => {
+    const dirigeant = {
+      ...identity,
+      family_name: "DuMoulin",
+      given_name: "Robert",
+      gender: "female" as const,
+    };
+    const result = match_identity_to_dirigeant(identity, [dirigeant]);
+    assert.equal(result.kind, "below_threshold");
+  });
+
+  it("picks the highest-scoring candidate among several", () => {
+    const weak = { ...identity, family_name: "DuMoulin", given_name: "Robert" };
+    const result = match_identity_to_dirigeant(identity, [weak, identity]);
+    assert.equal(result.kind, "exact_match");
+  });
+});

--- a/packages/identite/src/managers/certification/match-identity-to-dirigeant.ts
+++ b/packages/identite/src/managers/certification/match-identity-to-dirigeant.ts
@@ -1,0 +1,40 @@
+//
+
+import type { IdentityVector } from "#src/types";
+import { match } from "ts-pattern";
+import { certificationScore } from "./certification-score.js";
+
+//
+
+export function match_identity_to_dirigeant(
+  identity: IdentityVector,
+  dirigeants: IdentityVector[],
+) {
+  if (dirigeants.length === 0) return { kind: "no_candidates" as const };
+
+  const [closest] = dirigeants
+    .map((dirigeant) => ({
+      dirigeant,
+      matches: certificationScore(identity, dirigeant),
+    }))
+    .toSorted((a, b) => b.matches.size - a.matches.size); // Sort by score descending (higher is better)
+
+  // According to the specification, only score of 5 (perfect match) is certified
+  return match(closest.matches.size)
+    .with(5, () => ({
+      kind: "exact_match" as const,
+      closest,
+    }))
+    .with(4, () => ({
+      kind: "close_match" as const,
+      closest,
+    }))
+    .with(3, () => ({
+      kind: "close_match" as const,
+      closest,
+    }))
+    .otherwise(() => ({
+      kind: "below_threshold" as const,
+      closest,
+    }));
+}

--- a/packages/identite/src/managers/certification/process-certification-dirigeant.ts
+++ b/packages/identite/src/managers/certification/process-certification-dirigeant.ts
@@ -5,7 +5,6 @@ import { isOrganizationCoveredByCertificationDirigeant } from "#src/services/org
 import {
   NullIdentityVector,
   type FranceConnectUserInfo,
-  type IdentityVector,
   type Organization,
 } from "#src/types";
 import { match } from "ts-pattern";
@@ -14,7 +13,7 @@ import * as ApiEntreprise from "./adapters/api_entreprise.js";
 import * as FranceConnect from "./adapters/franceconnect.js";
 import * as INSEE from "./adapters/insee.js";
 import * as RNE from "./adapters/rne.js";
-import { certificationScore } from "./certification-score.js";
+import { match_identity_to_dirigeant } from "./match-identity-to-dirigeant.js";
 
 //
 
@@ -74,39 +73,6 @@ async function getMandatairesSociaux(
         ],
     };
   }
-}
-
-function match_identity_to_dirigeant(
-  identity: IdentityVector,
-  dirigeants: IdentityVector[],
-) {
-  if (dirigeants.length === 0) return { kind: "no_candidates" as const };
-
-  const [closest] = dirigeants
-    .map((dirigeant) => ({
-      dirigeant,
-      matches: certificationScore(identity, dirigeant),
-    }))
-    .toSorted((a, b) => b.matches.size - a.matches.size); // Sort by score descending (higher is better)
-
-  // According to the specification, only score of 5 (perfect match) is certified
-  return match(closest.matches.size)
-    .with(5, () => ({
-      kind: "exact_match" as const,
-      closest,
-    }))
-    .with(4, () => ({
-      kind: "close_match" as const,
-      closest,
-    }))
-    .with(3, () => ({
-      kind: "close_match" as const,
-      closest,
-    }))
-    .otherwise(() => ({
-      kind: "below_threshold" as const,
-      closest,
-    }));
 }
 
 export function processCertificationDirigeantFactory(context: Context) {


### PR DESCRIPTION
**Problem**
The dirigeant-ranking logic lived inside processCertificationDirigeantFactory's file, whose orchestrator awaits insee/rne/api_entreprise clients with a try/catch fallback. It was already pure and needed no I/O, but was only reachable through tests that mock those network clients just to exercise ranking.

**Proposal**
Move it into its own module and add zero-mock unit tests over plain IdentityVector objects for each outcome (no_candidates, exact_match, close_match, below_threshold, multi-candidate selection). process-certification-dirigeant.ts now imports it; behavior unchanged.