### PR TITLE
🔥 own Base64URLString, AuthenticatorTransportFuture, CredentialDeviceType locally

### DIFF
--- a/packages/identite/src/repositories/authenticator/update-authenticator.ts
+++ b/packages/identite/src/repositories/authenticator/update-authenticator.ts
@@ -2,10 +2,10 @@
 
 import type {
   Authenticator,
+  Base64URLString,
   BaseAuthenticator,
   DatabaseContext,
 } from "#src/types";
-import type { Base64URLString } from "@simplewebauthn/server";
 import { type QueryResult } from "pg";
 
 //

--- a/packages/identite/src/types/authenticator.ts
+++ b/packages/identite/src/types/authenticator.ts
@@ -1,10 +1,15 @@
 //
 
-import type {
-  AuthenticatorTransportFuture,
-  Base64URLString,
-  CredentialDeviceType,
-} from "@simplewebauthn/server";
+export type Base64URLString = string;
+export type AuthenticatorTransportFuture =
+  | "ble"
+  | "cable"
+  | "hybrid"
+  | "internal"
+  | "nfc"
+  | "smart-card"
+  | "usb";
+export type CredentialDeviceType = "singleDevice" | "multiDevice";
 
 //
 


### PR DESCRIPTION
**Problem**
packages/identite imported these three types from @simplewebauthn/server without declaring the package as a dependency — a phantom edge, and for a package aiming to stay pure, borrowing a WebAuthn library's vocabulary for what's really a plain string alias and two small spec-defined string unions is worse than undeclared, it's the wrong owner.

**Proposal**
Define all three locally in types/authenticator.ts (Base64URLString as string, the other two copied verbatim from @simplewebauthn/server's own .d.ts so the literal values stay correct). Removes the import entirely; grep -r simplewebauthn packages/identite/src now returns nothing.