### PR TITLE
🔥 own TrancheEffectifs locally instead of borrowing api_entreprise's

### DIFF
--- a/packages/identite/src/types/organization-info.ts
+++ b/packages/identite/src/types/organization-info.ts
@@ -1,6 +1,6 @@
 //
-import type { TrancheEffectifs } from "@proconnect-gouv/proconnect.api_entreprise/types";
 import { z } from "zod";
+import type { TrancheEffectifs } from "./organization.js";
 
 //
 

--- a/packages/identite/src/types/organization.ts
+++ b/packages/identite/src/types/organization.ts
@@ -1,6 +1,23 @@
 //
 
-import type { TrancheEffectifs } from "@proconnect-gouv/proconnect.api_entreprise/types";
+export type TrancheEffectifs =
+  | "NN"
+  | "00"
+  | "01"
+  | "02"
+  | "03"
+  | "11"
+  | "12"
+  | "21"
+  | "22"
+  | "31"
+  | "32"
+  | "41"
+  | "42"
+  | "51"
+  | "52"
+  | "53"
+  | null;
 
 //
 


### PR DESCRIPTION
**Problem**
identite's own Organization/OrganizationInfo domain types were defined by whatever api_entreprise.fr's OpenAPI spec happens to return (tranche_effectif_salarie.code), an undeclared import and the wrong owner for a package aiming to own its domain vocabulary.

**Proposal**
Define TrancheEffectifs locally in types/organization.ts as the same literal string union (copied from the openapi-generated type, values unchanged), re-export it through the existing types barrel, and import it from there in organization-info.ts. No behavior change.