### PR TITLE
🐛 fix self-import of ModerationNotFoundError in get-moderation-by-id

### DIFF
--- a/packages/identite/src/repositories/moderation/get-moderation-by-id.test.ts
+++ b/packages/identite/src/repositories/moderation/get-moderation-by-id.test.ts
@@ -1,7 +1,7 @@
 //
 
+import { ModerationNotFoundError } from "#src/errors";
 import { emptyDatabase, migrate, pg } from "#testing";
-import { ModerationNotFoundError } from "@proconnect-gouv/proconnect.identite/errors";
 import assert from "node:assert/strict";
 import { before, beforeEach, suite, test } from "node:test";
 import { getModerationByIdFactory } from "./get-moderation-by-id.js";

--- a/packages/identite/src/repositories/moderation/get-moderation-by-id.ts
+++ b/packages/identite/src/repositories/moderation/get-moderation-by-id.ts
@@ -1,7 +1,7 @@
 //
 
+import { ModerationNotFoundError } from "#src/errors";
 import { type DatabaseContext, type Moderation } from "#src/types";
-import { ModerationNotFoundError } from "@proconnect-gouv/proconnect.identite/errors";
 import { findModerationByIdFactory } from "./find-moderation-by-id.js";
 
 //


### PR DESCRIPTION
**Problem**
get-moderation-by-id.ts imported ModerationNotFoundError through the external self-import @proconnect-gouv/proconnect.identite/errors instead of the internal #src/errors alias every other repository file uses. That subpath resolves through the workspace symlink to this package's built dist output, while #src/errors resolves to live source under tsx — two different class identities. Its test imported the same external path, so both sides matched by luck; fixing only the production file would have broken the test's instanceof check with a dist-vs-source dual-class mismatch.

**Proposal**
Switch both the production file and its test to #src/errors, matching the convention used elsewhere (e.g. mark-domain-as-verified.test.ts). No behavior change once both sides agree on one class identity.