### PR TITLE
♻️ Homogenize `get` and `find` usage in repository functions

### DIFF
--- a/packages/identite/src/connectors/index.ts
+++ b/packages/identite/src/connectors/index.ts
@@ -4,7 +4,7 @@ import {
   createAuthenticatorFactory,
   deleteAuthenticatorFactory,
   findAuthenticatorFactory,
-  getAuthenticatorsByUserIdFactory,
+  findAuthenticatorsByUserIdFactory,
   updateAuthenticatorFactory,
 } from "#src/repositories/authenticator";
 import { findEmailInDeliverabilityWhiteListFactory } from "#src/repositories/email-deliverability-whitelist";
@@ -37,8 +37,8 @@ import {
   findByVerifiedEmailDomainFactory,
   findOrganizationByIdFactory,
   findPendingByUserIdFactory,
+  findUsersByOrganizationFactory,
   getOrganizationByIdFactory,
-  getUsersByOrganizationFactory,
   upsertFactory,
 } from "#src/repositories/organization";
 import {
@@ -48,9 +48,9 @@ import {
   findByEmailFactory,
   findByMagicLinkTokenFactory,
   findByResetPasswordTokenFactory,
+  findFranceConnectUserInfoFactory,
   findByIdFactory as findUserByIdFactory,
   getByIdFactory,
-  getFranceConnectUserInfoFactory,
   updateUserFactory,
   upsertFranceconnectUserinfoFactory,
 } from "#src/repositories/user";
@@ -89,7 +89,7 @@ export function createContext({
         createAuthenticator: createAuthenticatorFactory({ pg }),
         deleteAuthenticator: deleteAuthenticatorFactory({ pg }),
         findAuthenticator: findAuthenticatorFactory({ pg }),
-        getAuthenticatorsByUserId: getAuthenticatorsByUserIdFactory({ pg }),
+        findAuthenticatorsByUserId: findAuthenticatorsByUserIdFactory({ pg }),
         updateAuthenticator: updateAuthenticatorFactory({ pg }),
       },
       email_deliverability_whitelist: {
@@ -127,8 +127,8 @@ export function createContext({
         findByUserId: findByUserIdFactory({ pg }),
         findByVerifiedEmailDomain: findByVerifiedEmailDomainFactory({ pg }),
         findPendingByUserId: findPendingByUserIdFactory({ pg }),
+        findUsers: findUsersByOrganizationFactory({ pg }),
         getById: getOrganizationByIdFactory({ pg }),
-        getUsers: getUsersByOrganizationFactory({ pg }),
         upsert: upsertFactory({ pg }),
       },
       users_organizations: {
@@ -145,8 +145,8 @@ export function createContext({
         findById: findUserByIdFactory({ pg }),
         findByMagicLinkToken: findByMagicLinkTokenFactory({ pg }),
         findByResetPasswordToken: findByResetPasswordTokenFactory({ pg }),
+        findFranceConnectUserInfo: findFranceConnectUserInfoFactory({ pg }),
         getById: getByIdFactory({ pg }),
-        getFranceConnectUserInfo: getFranceConnectUserInfoFactory({ pg }),
         update: updateUserFactory({ pg }),
         upsetFranceconnectUserinfo: upsertFranceconnectUserinfoFactory({ pg }),
       },

--- a/packages/identite/src/managers/user/assign-user-verification-type-to-domain.ts
+++ b/packages/identite/src/managers/user/assign-user-verification-type-to-domain.ts
@@ -13,7 +13,7 @@ export function assignUserVerificationTypeToDomainFactory({
     organization_id: number,
     domain: string,
   ) {
-    const usersInOrganization = await organizations.getUsers(organization_id);
+    const usersInOrganization = await organizations.findUsers(organization_id);
 
     await Promise.all(
       usersInOrganization.map(

--- a/packages/identite/src/repositories/authenticator/find-authenticators-by-user-id.test.ts
+++ b/packages/identite/src/repositories/authenticator/find-authenticators-by-user-id.test.ts
@@ -3,20 +3,20 @@
 import { emptyDatabase, migrate, pg } from "#testing";
 import assert from "node:assert/strict";
 import { before, beforeEach, suite, test } from "node:test";
-import { getAuthenticatorsByUserIdFactory } from "./get-authenticators-by-user-id.js";
+import { findAuthenticatorsByUserIdFactory } from "./find-authenticators-by-user-id.js";
 
 //
 
-const getAuthenticatorsByUserId = getAuthenticatorsByUserIdFactory({
+const findAuthenticatorsByUserId = findAuthenticatorsByUserIdFactory({
   pg: pg as any,
 });
 
-suite("getAuthenticatorsByUserIdFactory", () => {
+suite("findAuthenticatorsByUserIdFactory", () => {
   before(migrate);
   beforeEach(emptyDatabase);
 
   test("should return empty array when user has no authenticators", async () => {
-    const authenticators = await getAuthenticatorsByUserId(1);
+    const authenticators = await findAuthenticatorsByUserId(1);
 
     assert.deepEqual(authenticators, []);
   });
@@ -37,7 +37,7 @@ suite("getAuthenticatorsByUserIdFactory", () => {
       ;
     `;
 
-    const authenticators = await getAuthenticatorsByUserId(1);
+    const authenticators = await findAuthenticatorsByUserId(1);
 
     assert.equal(authenticators.length, 1);
     assert.equal(authenticators[0]?.credential_id, "CRED1");

--- a/packages/identite/src/repositories/authenticator/find-authenticators-by-user-id.ts
+++ b/packages/identite/src/repositories/authenticator/find-authenticators-by-user-id.ts
@@ -5,8 +5,8 @@ import { type QueryResult } from "pg";
 
 //
 
-export function getAuthenticatorsByUserIdFactory({ pg }: DatabaseContext) {
-  return async function getAuthenticatorsByUserId(user_id: number) {
+export function findAuthenticatorsByUserIdFactory({ pg }: DatabaseContext) {
+  return async function findAuthenticatorsByUserId(user_id: number) {
     const { rows }: QueryResult<Authenticator> = await pg.query(
       `
         SELECT *

--- a/packages/identite/src/repositories/authenticator/index.ts
+++ b/packages/identite/src/repositories/authenticator/index.ts
@@ -3,5 +3,5 @@
 export * from "./create-authenticator.js";
 export * from "./delete-authenticator.js";
 export * from "./find-authenticator.js";
-export * from "./get-authenticators-by-user-id.js";
+export * from "./find-authenticators-by-user-id.js";
 export * from "./update-authenticator.js";

--- a/packages/identite/src/repositories/organization/find-users-by-organization.test.ts
+++ b/packages/identite/src/repositories/organization/find-users-by-organization.test.ts
@@ -3,13 +3,15 @@
 import { emptyDatabase, migrate, pg } from "#testing";
 import assert from "node:assert/strict";
 import { before, beforeEach, describe, it } from "node:test";
-import { getUsersByOrganizationFactory } from "./get-users-by-organization.js";
+import { findUsersByOrganizationFactory } from "./find-users-by-organization.js";
 
 //
 
-const getUsersByOrganization = getUsersByOrganizationFactory({ pg: pg as any });
+const findUsersByOrganization = findUsersByOrganizationFactory({
+  pg: pg as any,
+});
 
-describe("getUsersByOrganizationFactory", () => {
+describe("findUsersByOrganizationFactory", () => {
   before(migrate);
   beforeEach(emptyDatabase);
 
@@ -37,13 +39,13 @@ describe("getUsersByOrganizationFactory", () => {
       ;
     `;
 
-    const user = await getUsersByOrganization(1);
+    const user = await findUsersByOrganization(1);
 
     t.assert.snapshot(user);
   });
 
   it("❎ fail to find users for unknown organization id", async () => {
-    const user = await getUsersByOrganization(42);
+    const user = await findUsersByOrganization(42);
     assert.deepEqual(user, []);
   });
 });

--- a/packages/identite/src/repositories/organization/find-users-by-organization.test.ts.snapshot
+++ b/packages/identite/src/repositories/organization/find-users-by-organization.test.ts.snapshot
@@ -1,4 +1,4 @@
-exports[`getUsersByOrganizationFactory > should find users by organization id 1`] = `
+exports[`findUsersByOrganizationFactory > should find users by organization id 1`] = `
 [
   {
     "id": 1,

--- a/packages/identite/src/repositories/organization/find-users-by-organization.ts
+++ b/packages/identite/src/repositories/organization/find-users-by-organization.ts
@@ -9,8 +9,8 @@ import type { QueryResult } from "pg";
 
 //
 
-export function getUsersByOrganizationFactory({ pg }: DatabaseContext) {
-  return async function getUsersByOrganization(
+export function findUsersByOrganizationFactory({ pg }: DatabaseContext) {
+  return async function findUsersByOrganization(
     organization_id: number,
     additionalWhereClause: string = "",
     additionalParams: any[] = [],
@@ -36,7 +36,3 @@ export function getUsersByOrganizationFactory({ pg }: DatabaseContext) {
     return rows;
   };
 }
-
-export type GetUsersByOrganizationHandler = ReturnType<
-  typeof getUsersByOrganizationFactory
->;

--- a/packages/identite/src/repositories/organization/index.ts
+++ b/packages/identite/src/repositories/organization/index.ts
@@ -5,6 +5,6 @@ export * from "./find-by-user-id.js";
 export * from "./find-by-verified-email-domain.js";
 export * from "./find-organization-by-id.js";
 export * from "./find-pending-by-user-id.js";
+export * from "./find-users-by-organization.js";
 export * from "./get-organization-by-id.js";
-export * from "./get-users-by-organization.js";
 export * from "./upsert.js";

--- a/packages/identite/src/repositories/user/delete-franceconnect-userinfo.test.ts
+++ b/packages/identite/src/repositories/user/delete-franceconnect-userinfo.test.ts
@@ -4,14 +4,14 @@ import { emptyDatabase, migrate, pg } from "#testing";
 import assert from "node:assert/strict";
 import { before, beforeEach, describe, it } from "node:test";
 import { deleteFranceConnectUserInfoFactory } from "./delete-franceconnect-userinfo.js";
-import { getFranceConnectUserInfoFactory } from "./get-franceconnect-user-info.js";
+import { findFranceConnectUserInfoFactory } from "./find-franceconnect-user-info.js";
 
 //
 
 const deleteFranceConnectUserInfo = deleteFranceConnectUserInfoFactory({
   pg: pg as any,
 });
-const getFranceConnectUserInfo = getFranceConnectUserInfoFactory({
+const findFranceConnectUserInfo = findFranceConnectUserInfoFactory({
   pg: pg as any,
 });
 
@@ -37,7 +37,7 @@ describe("deleteFranceConnectUserInfo", () => {
 
     await deleteFranceConnectUserInfo(1);
 
-    const user = await getFranceConnectUserInfo(1);
+    const user = await findFranceConnectUserInfo(1);
     assert.equal(user, undefined);
   });
 

--- a/packages/identite/src/repositories/user/find-franceconnect-user-info.test.ts
+++ b/packages/identite/src/repositories/user/find-franceconnect-user-info.test.ts
@@ -3,15 +3,15 @@
 import { emptyDatabase, migrate, pg } from "#testing";
 import assert from "node:assert/strict";
 import { before, beforeEach, describe, it, mock } from "node:test";
-import { getFranceConnectUserInfoFactory } from "./get-franceconnect-user-info.js";
+import { findFranceConnectUserInfoFactory } from "./find-franceconnect-user-info.js";
 
 //
 
-const getFranceConnectUserInfo = getFranceConnectUserInfoFactory({
+const findFranceConnectUserInfo = findFranceConnectUserInfoFactory({
   pg: pg as any,
 });
 
-describe("getFranceConnectUserInfo", () => {
+describe("findFranceConnectUserInfo", () => {
   before(migrate);
   beforeEach(emptyDatabase);
   before(() => {
@@ -34,7 +34,7 @@ describe("getFranceConnectUserInfo", () => {
       ;
     `;
 
-    const user = await getFranceConnectUserInfo(1);
+    const user = await findFranceConnectUserInfo(1);
     assert.ok(user);
     assert.deepEqual(user, {
       birthcountry: null,
@@ -52,7 +52,7 @@ describe("getFranceConnectUserInfo", () => {
   });
 
   it("❎ fail to get an unknown user", async () => {
-    const user = await getFranceConnectUserInfo(42);
+    const user = await findFranceConnectUserInfo(42);
 
     assert.equal(user, undefined);
   });

--- a/packages/identite/src/repositories/user/find-franceconnect-user-info.ts
+++ b/packages/identite/src/repositories/user/find-franceconnect-user-info.ts
@@ -5,8 +5,8 @@ import { type QueryResult } from "pg";
 
 //
 
-export function getFranceConnectUserInfoFactory({ pg }: DatabaseContext) {
-  return async function getFranceConnectUserInfo(user_id: number) {
+export function findFranceConnectUserInfoFactory({ pg }: DatabaseContext) {
+  return async function findFranceConnectUserInfo(user_id: number) {
     const { rows }: QueryResult<FranceConnectUserInfo> = await pg.query(
       `
       SELECT *
@@ -19,7 +19,3 @@ export function getFranceConnectUserInfoFactory({ pg }: DatabaseContext) {
     return rows.shift();
   };
 }
-
-export type GetFranceConnectUserInfoHandler = ReturnType<
-  typeof getFranceConnectUserInfoFactory
->;

--- a/packages/identite/src/repositories/user/index.ts
+++ b/packages/identite/src/repositories/user/index.ts
@@ -7,7 +7,7 @@ export * from "./find-by-email.js";
 export * from "./find-by-id.js";
 export * from "./find-by-magic-link-token.js";
 export * from "./find-by-reset-password-token.js";
+export * from "./find-franceconnect-user-info.js";
 export * from "./get-by-id.js";
-export * from "./get-franceconnect-user-info.js";
 export * from "./update.js";
 export * from "./upsert-franceconnect-userinfo.js";

--- a/src/controllers/organization.ts
+++ b/src/controllers/organization.ts
@@ -42,7 +42,6 @@ import {
   upsertOrganization,
 } from "../managers/organization/join";
 import {
-  getOrganizationById,
   quitOrganization,
   selectOrganization,
 } from "../managers/organization/main";
@@ -57,7 +56,7 @@ import {
 import getNotificationsFromRequest from "../services/get-notifications-from-request";
 import hasErrorFromField from "../services/has-error-from-field";
 
-const { moderations, users } = context.repository;
+const { moderations, organizations, users } = context.repository;
 
 export const getJoinOrganizationController = async (
   req: Request,
@@ -265,7 +264,7 @@ export const getDomainNotAllowedForOrganizationController = async (
 
     const { organization_id } = await schema.parseAsync(req.query);
 
-    const organization = await getOrganizationById(organization_id);
+    const organization = await organizations.findById(organization_id);
     if (isEmpty(organization)) {
       return next(new HttpErrors.NotFound());
     }
@@ -294,7 +293,7 @@ export const getDomainRefusedForOrganizationController = async (
 
     const { organization_id } = await schema.parseAsync(req.query);
 
-    const organization = await getOrganizationById(organization_id);
+    const organization = await organizations.findById(organization_id);
     if (isEmpty(organization)) {
       return next(new HttpErrors.NotFound());
     }
@@ -321,7 +320,7 @@ export const getJoinOrganizationConfirmController = async (
 
     const { organization_id } = await schema.parseAsync(req.query);
 
-    const organization = await getOrganizationById(organization_id);
+    const organization = await organizations.findById(organization_id);
 
     if (isEmpty(organization)) {
       return next(new HttpErrors.NotFound());
@@ -466,7 +465,7 @@ export async function getCertificationDirigeantCloseMatchError(
       .parse(req.query);
 
     const user = getUserFromAuthenticatedSession(req);
-    const user_info = await users.getFranceConnectUserInfo(user.id);
+    const user_info = await users.findFranceConnectUserInfo(user.id);
 
     const dataSourceLabel = getCertificationDirigeantDataSourceLabels(
       query.source,

--- a/src/controllers/user/official-contact-ask-which-email.ts
+++ b/src/controllers/user/official-contact-ask-which-email.ts
@@ -3,10 +3,12 @@ import HttpErrors from "http-errors";
 import { isEmpty } from "lodash-es";
 import { ApiAnnuaireError } from "../../config/errors";
 import { getAnnuaireServicePublicContactEmails } from "../../connectors/api-annuaire-service-public";
-import { getOrganizationById } from "../../managers/organization/main";
+import { context } from "../../connectors/context";
 import { csrfToken } from "../../middlewares/csrf-protection";
 import getNotificationsFromRequest from "../../services/get-notifications-from-request";
 import { getOrganizationTypeLabel } from "../../services/organization";
+
+const { organizations } = context.repository;
 
 export const getOfficialContactAskWhichEmailController = async (
   req: Request,
@@ -16,7 +18,7 @@ export const getOfficialContactAskWhichEmailController = async (
   try {
     const organization_id =
       req.session.pendingOfficialContactEmailVerificationOrganizationId!;
-    const organization = await getOrganizationById(organization_id);
+    const organization = await organizations.findById(organization_id);
     if (isEmpty(organization)) {
       throw HttpErrors.NotFound();
     }

--- a/src/controllers/user/official-contact-email-verification.ts
+++ b/src/controllers/user/official-contact-email-verification.ts
@@ -7,10 +7,8 @@ import {
   InvalidTokenError,
   OfficialContactEmailVerificationNotNeededError,
 } from "../../config/errors";
-import {
-  getOrganizationById,
-  selectOrganization,
-} from "../../managers/organization/main";
+import { context } from "../../connectors/context";
+import { selectOrganization } from "../../managers/organization/main";
 import {
   sendOfficialContactEmailVerificationEmail,
   verifyOfficialContactEmailToken,
@@ -24,6 +22,8 @@ import {
 import getNotificationsFromRequest from "../../services/get-notifications-from-request";
 import { getOrganizationTypeLabel } from "../../services/organization";
 
+const { organizations } = context.repository;
+
 export const getOfficialContactEmailVerificationController = async (
   req: Request,
   res: Response,
@@ -32,7 +32,7 @@ export const getOfficialContactEmailVerificationController = async (
   try {
     const organization_id =
       req.session.pendingOfficialContactEmailVerificationOrganizationId!;
-    const organization = await getOrganizationById(organization_id);
+    const organization = await organizations.findById(organization_id);
     if (isEmpty(organization)) {
       throw HttpErrors.NotFound();
     }
@@ -97,7 +97,7 @@ export const postOfficialContactEmailVerificationMiddleware = async (
     const { id: user_id } = getUserFromAuthenticatedSession(req);
     const organization_id =
       req.session.pendingOfficialContactEmailVerificationOrganizationId!;
-    const organization = await getOrganizationById(organization_id);
+    const organization = await organizations.findById(organization_id);
     if (isEmpty(organization)) {
       throw HttpErrors.NotFound();
     }

--- a/src/controllers/user/select-organization.ts
+++ b/src/controllers/user/select-organization.ts
@@ -1,12 +1,12 @@
 import type { NextFunction, Request, Response } from "express";
 import { z } from "zod";
-import {
-  getOrganizationsByUserId,
-  selectOrganization,
-} from "../../managers/organization/main";
+import { context } from "../../connectors/context";
+import { selectOrganization } from "../../managers/organization/main";
 import { getUserFromAuthenticatedSession } from "../../managers/session/authenticated";
 import { csrfToken } from "../../middlewares/csrf-protection";
 import { idSchema } from "../../services/custom-zod-schemas";
+
+const { organizations } = context.repository;
 
 export const getSelectOrganizationController = async (
   req: Request,
@@ -14,7 +14,7 @@ export const getSelectOrganizationController = async (
   next: NextFunction,
 ) => {
   try {
-    const userOrganizations = await getOrganizationsByUserId(
+    const userOrganizations = await organizations.findByUserId(
       getUserFromAuthenticatedSession(req).id,
     );
 

--- a/src/controllers/user/welcome.ts
+++ b/src/controllers/user/welcome.ts
@@ -2,7 +2,6 @@ import { NotFoundError } from "@proconnect-gouv/proconnect.identite/errors";
 import type { NextFunction, Request, Response } from "express";
 import { isEmpty } from "lodash-es";
 import { context } from "../../connectors/context";
-import { getOrganizationById } from "../../managers/organization/main";
 import {
   getUserFromAuthenticatedSession,
   updateUserInAuthenticatedSession,
@@ -10,7 +9,7 @@ import {
 import { csrfToken } from "../../middlewares/csrf-protection";
 import { getSelectedOrganizationId } from "../../repositories/redis/selected-organization";
 
-const { users } = context.repository;
+const { organizations, users } = context.repository;
 
 export const getWelcomeController = async (
   req: Request,
@@ -31,7 +30,7 @@ export const getWelcomeController = async (
     let organization = null;
 
     if (selectedOrganizationId !== null) {
-      const userOrganisation = await getOrganizationById(
+      const userOrganisation = await organizations.findById(
         selectedOrganizationId,
       );
 
@@ -82,12 +81,14 @@ export const getWelcomeDirigeantController = async (
     if (selectedOrganizationId === null)
       throw new NotFoundError("Selected organization not found");
 
-    const userOrganisations = await getOrganizationById(selectedOrganizationId);
+    const userOrganisations = await organizations.findById(
+      selectedOrganizationId,
+    );
 
     if (!userOrganisations)
       throw new NotFoundError("User in organization not found");
 
-    const user_info = await users.getFranceConnectUserInfo(user.id);
+    const user_info = await users.findFranceConnectUserInfo(user.id);
 
     if (isEmpty(user_info))
       throw new NotFoundError("FranceConnect User info not found");

--- a/src/managers/organization/join.ts
+++ b/src/managers/organization/join.ts
@@ -66,7 +66,7 @@ import {
   isSmallOrganization,
 } from "../../services/organization";
 import { unableToAutoJoinOrganizationMd } from "../../views/mails/unable-to-auto-join-organization";
-import { getOrganizationsByUserId, markDomainAsVerified } from "./main";
+import { markDomainAsVerified } from "./main";
 
 const {
   email_domains,
@@ -426,7 +426,7 @@ export const greetForJoiningOrganization = async ({
   user_id: number;
   organization_id: number;
 }) => {
-  const userOrganisations = await getOrganizationsByUserId(user_id);
+  const userOrganisations = await organizations.findByUserId(user_id);
   const organization = userOrganisations.find(
     ({ id }) => id === organization_id,
   );
@@ -462,7 +462,7 @@ export const greetForCertification = async ({
   user_id: number;
   organization_id: number;
 }) => {
-  const userOrganisations = await getOrganizationsByUserId(user_id);
+  const userOrganisations = await organizations.findByUserId(user_id);
   const organization = userOrganisations.find(
     ({ id }) => id === organization_id,
   );

--- a/src/managers/organization/main.ts
+++ b/src/managers/organization/main.ts
@@ -7,16 +7,13 @@ import { setSelectedOrganizationId } from "../../repositories/redis/selected-org
 
 const { organizations, users_organizations } = context.repository;
 
-export const getOrganizationsByUserId = organizations.findByUserId;
-export const getOrganizationById = organizations.findById;
-export const getOrganizationBySiret = organizations.findBySiret;
 export const getUserOrganizations = async (
   userId: number,
 ): Promise<{
   userOrganizations: Organization[];
   pendingUserOrganizations: Organization[];
 }> => {
-  const userOrganizations = await getOrganizationsByUserId(userId);
+  const userOrganizations = await organizations.findByUserId(userId);
   const pendingUserOrganizations =
     await organizations.findPendingByUserId(userId);
 
@@ -50,7 +47,7 @@ export const selectOrganization = async ({
   user_id: number;
   organization_id: number;
 }) => {
-  const userOrganizations = await getOrganizationsByUserId(user_id);
+  const userOrganizations = await organizations.findByUserId(user_id);
   const organization = userOrganizations.find(
     ({ id }) => id === organization_id,
   );

--- a/src/managers/user.ts
+++ b/src/managers/user.ts
@@ -560,7 +560,7 @@ export const updatePersonalInformationsForRegistration = async (
     job,
   }: Pick<User, "given_name" | "family_name" | "job">,
 ): Promise<User> => {
-  const isUserVerified = await users.getFranceConnectUserInfo(userId);
+  const isUserVerified = await users.findFranceConnectUserInfo(userId);
   const names = isUserVerified ? {} : { given_name, family_name };
 
   return users.update(userId, {
@@ -570,7 +570,7 @@ export const updatePersonalInformationsForRegistration = async (
 };
 
 export async function hasValidFranceConnectIdentity(userId: number) {
-  const userFranceConnect = await users.getFranceConnectUserInfo(userId);
+  const userFranceConnect = await users.findFranceConnectUserInfo(userId);
 
   if (isEmpty(userFranceConnect)) {
     return false;
@@ -583,7 +583,7 @@ export async function hasValidFranceConnectIdentity(userId: number) {
 }
 
 export async function lastFranceConnectIdentityUpdate(userId: number) {
-  const userFranceConnect = await users.getFranceConnectUserInfo(userId);
+  const userFranceConnect = await users.findFranceConnectUserInfo(userId);
   if (isEmpty(userFranceConnect)) return false;
   return userFranceConnect.updated_at;
 }
@@ -617,7 +617,7 @@ export async function updateFranceConnectUserInfo(
 export async function getGivenNameOptionsFromFranceConnectIdentity(
   userId: number,
 ): Promise<string[]> {
-  const franceconnectUserinfo = await users.getFranceConnectUserInfo(userId);
+  const franceconnectUserinfo = await users.findFranceConnectUserInfo(userId);
 
   if (!franceconnectUserinfo) {
     return [];
@@ -632,7 +632,7 @@ export async function getGivenNameOptionsFromFranceConnectIdentity(
 export async function getFamilyNameOptionsFromFranceConnectIdentity(
   userId: number,
 ): Promise<string[]> {
-  const franceconnectUserinfo = await users.getFranceConnectUserInfo(userId);
+  const franceconnectUserinfo = await users.findFranceConnectUserInfo(userId);
 
   if (!franceconnectUserinfo) {
     return [];

--- a/src/managers/webauthn.ts
+++ b/src/managers/webauthn.ts
@@ -42,7 +42,7 @@ export const isWebauthnConfiguredForUser = async (user_id: number) => {
   await users.getById(user_id);
 
   const userAuthenticators =
-    await authenticators.getAuthenticatorsByUserId(user_id);
+    await authenticators.findAuthenticatorsByUserId(user_id);
   return !isEmpty(userAuthenticators);
 };
 
@@ -53,7 +53,7 @@ export const getUserAuthenticators = async (email: string) => {
     throw new NotFoundError();
   }
 
-  const userAuthenticators = await authenticators.getAuthenticatorsByUserId(
+  const userAuthenticators = await authenticators.findAuthenticatorsByUserId(
     user.id,
   );
 
@@ -112,7 +112,7 @@ export const getRegistrationOptions = async (email: string) => {
   }
 
   // Retrieve any of the user's previously-registered authenticators
-  const userAuthenticators = await authenticators.getAuthenticatorsByUserId(
+  const userAuthenticators = await authenticators.findAuthenticatorsByUserId(
     user.id,
   );
 
@@ -239,7 +239,7 @@ export const getAuthenticationOptions = async (
   }
 
   // Retrieve any of the user's previously registered authenticators
-  const userAuthenticators = await authenticators.getAuthenticatorsByUserId(
+  const userAuthenticators = await authenticators.findAuthenticatorsByUserId(
     user.id,
   );
 

--- a/src/middlewares/navigation-guards.ts
+++ b/src/middlewares/navigation-guards.ts
@@ -4,6 +4,10 @@ import type { Request, RequestHandler } from "express";
 import HttpErrors from "http-errors";
 import { isEmpty } from "lodash-es";
 import { match, P } from "ts-pattern";
+import type {
+  BaseUserOrganizationLink,
+  Organization,
+} from "../../packages/identite/src/types";
 import {
   CERTIFICATION_DIRIGEANT_MAX_AGE_IN_MINUTES,
   HOST,
@@ -26,11 +30,7 @@ import {
   greetForCertification,
   greetForJoiningOrganization,
 } from "../managers/organization/join";
-import {
-  getOrganizationBySiret,
-  getOrganizationsByUserId,
-  selectOrganization,
-} from "../managers/organization/main";
+import { selectOrganization } from "../managers/organization/main";
 import { isCommuneWithMultipleOfficialContactEmails } from "../managers/organization/official-contact-email-verification";
 import {
   getCurrentAcr,
@@ -63,10 +63,6 @@ const { organizations, users_organizations, users } = context.repository;
 //
 
 type RequestContext = { req: Request };
-
-type UserOrganizationsByUserId = Awaited<
-  ReturnType<typeof getOrganizationsByUserId>
->;
 
 type Redirect = {
   type: "redirect";
@@ -431,7 +427,7 @@ const userHasAtLeastOneOrganizationGuard = async (
     redirect,
   } = context;
 
-  const userOrganizations = await getOrganizationsByUserId(
+  const userOrganizations = await organizations.findByUserId(
     getUserFromAuthenticatedSession(req).id,
   );
   if (isEmpty(userOrganizations)) {
@@ -463,7 +459,7 @@ export const userHasAtLeastOneOrganizationGuardMiddleware =
 
 const userBelongsToHintedOrganizationGuard = async <
   TContext extends RequestContext & {
-    userOrganizations: UserOrganizationsByUserId;
+    userOrganizations: (Organization & BaseUserOrganizationLink)[];
   },
 >(
   context: Pass<TContext>,
@@ -474,7 +470,7 @@ const userBelongsToHintedOrganizationGuard = async <
     redirect,
   } = context;
   if (req.session.siretHint) {
-    const hintedOrganization = await getOrganizationBySiret(
+    const hintedOrganization = await organizations.findBySiret(
       req.session.siretHint,
     );
     const userFromAuthenticatedSession = getUserFromAuthenticatedSession(req);
@@ -501,7 +497,7 @@ const userBelongsToHintedOrganizationGuard = async <
 
 const userHasSelectedAnOrganizationGuard = async <
   TContext extends RequestContext & {
-    userOrganizations: UserOrganizationsByUserId;
+    userOrganizations: (Organization & BaseUserOrganizationLink)[];
   },
 >(
   context: Pass<TContext>,
@@ -644,7 +640,7 @@ const userIsCertifiedAsDirigeantGuard = async <
 
   if (linkType === LinkEnum.enum.organization_dirigeant) {
     const franceconnectUserInfo =
-      (await users.getFranceConnectUserInfo(user_id))!;
+      (await users.findFranceConnectUserInfo(user_id))!;
     const expiredCertification = isExpired(
       linkVerifiedAt,
       CERTIFICATION_DIRIGEANT_MAX_AGE_IN_MINUTES,
@@ -670,7 +666,7 @@ const userHasBeenGreetedGuard = async (context: Pass<RequestContext>) => {
   } = context;
   const { id: user_id } = getUserFromAuthenticatedSession(req);
 
-  const userOrganizations = await getOrganizationsByUserId(user_id);
+  const userOrganizations = await organizations.findByUserId(user_id);
 
   let organizationThatNeedsGreetings;
 
@@ -793,7 +789,7 @@ const processCertificationDirigeantGuard = async (
   }
 
   const franceconnectUserInfo =
-    (await users.getFranceConnectUserInfo(user_id))!;
+    (await users.findFranceConnectUserInfo(user_id))!;
   const organization = await organizations.getById(organization_id);
 
   try {

--- a/src/services/oidc-policy.ts
+++ b/src/services/oidc-policy.ts
@@ -1,7 +1,9 @@
 import { to } from "await-to-js";
 import { interactionPolicy } from "oidc-provider";
-import { getOrganizationById } from "../managers/organization/main";
+import { context } from "../connectors/context";
 import { getSelectedOrganizationId } from "../repositories/redis/selected-organization";
+
+const { organizations } = context.repository;
 
 //
 
@@ -31,7 +33,7 @@ policy.add(
 
         const oidcContextParams = ctx.oidc.params as OIDCContextParams;
         if (oidcContextParams.siret_hint && selectedOrganizationId) {
-          const selectedOrganization = (await getOrganizationById(
+          const selectedOrganization = (await organizations.findById(
             selectedOrganizationId,
           ))!;
           if (selectedOrganization.siret !== oidcContextParams.siret_hint) {


### PR DESCRIPTION
**Problem**

`get` and `find` are used arbitrarily as verbs within repositories.

**Proposal**

Use `find` when the function may return empty results.

Use `get` when the function throws if no result is found.
